### PR TITLE
Replacing parse-cron with rufus-scheduler parseline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "sidekiq", ">= 2.13.1"
-gem 'parse-cron', '>= 0.1.2'
+gem 'rufus-scheduler', '>= 2.0.24'
 
 group :development do
   gem "bundler"

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -1,7 +1,7 @@
 require 'sidekiq'
 require 'sidekiq/util'
 require 'sidekiq/actor'
-require 'parse-cron'
+require 'rufus-scheduler'
 
 module Sidekiq
   module Cron
@@ -263,8 +263,8 @@ module Sidekiq
           errors << "'cron' must be set" 
         else
           begin 
-            cron = CronParser.new(@cron)
-            cron.next(Time.now)
+            cron = Rufus::CronLine.new(@cron)
+            cron.next_time(Time.now)
           rescue Exception => e
             #fix for different versions of cron-parser
             if e.message == "Bad Vixie-style specification bad"
@@ -339,7 +339,7 @@ module Sidekiq
         # add 1 minute to Time now - Cron parser return last time after minute ends,
         # so by adding 60 second we will get last time after the right time happens 
         # without any delay!
-        CronParser.new(@cron).last(now + 60)
+        Rufus::CronLine.new(@cron).previous_time(now)
       end
 
       def formated_last_time now = Time.now

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<shotgun>, [">= 0"])
     else
       s.add_dependency(%q<sidekiq>, [">= 2.13.1"])
-      s.add_dependency(%q<parse-cron>, [">= 0.1.2"])
+      s.add_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
       s.add_dependency(%q<bundler>, [">= 0"])
       s.add_dependency(%q<simplecov>, [">= 0"])
       s.add_dependency(%q<shoulda-context>, [">= 0"])

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -523,9 +523,9 @@ class CronJobTest < Test::Unit::TestCase
           #set something bag to hash
           @jobs_hash['name_of_job']['cron'] = "bad cron"
           out = Sidekiq::Cron::Job.load_from_hash @jobs_hash
-          assert_equal out.size, 1, "should have 1 error"
-          assert_equal out, {"name_of_job"=>["'cron' -> bad cron: not a valid cronline"]}
-          assert_equal Sidekiq::Cron::Job.all.size, 1, "Should have only 1 job after load"          
+          assert_equal 1, out.size, "should have 1 error"
+          assert_equal ({"name_of_job"=>["'cron' -> bad cron: not a valid cronline : 'bad cron'"]}), out
+          assert_equal 1, Sidekiq::Cron::Job.all.size, "Should have only 1 job after load"          
         end
 
         should "create new jobs and then destroy them all" do


### PR DESCRIPTION
This is a suggestion. Rufus-scheduler cron is able to work with the 'seconds' dimension and retains all the parse-cron features.
