### PR TITLE
[FIX] no_translaion arguments error

### DIFF
--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -48,7 +48,7 @@
                 <input class='btn btn-mini pull-left' type="submit" name="enable" value="<%= no_translation('Enable') %>"/>
               </form>
               <form action="<%= root_path %>cron/<%= job.name %>/delete" method="post">
-                <input class='btn btn-mini btn-danger pull-left' type="submit" name="delete" value="<%= no_translation('Delete') %>" data-confirm="<%= no_translation('AreYouSureDeleteCronJob', :job => job.name) %>"/>
+                <input class='btn btn-mini btn-danger pull-left' type="submit" name="delete" value="<%= no_translation('Delete') %>" data-confirm="<%= no_translation('AreYouSureDeleteCronJob') %>"/>
               </form>
             <% end %>
           </td>

--- a/lib/sidekiq/cron/views/cron.slim
+++ b/lib/sidekiq/cron/views/cron.slim
@@ -41,7 +41,7 @@ header.row
             form action="#{root_path}cron/#{job.name}/enable" method="post"
               input.btn.btn-small.pull-left type="submit" name="enable" value="#{no_translation('Enable')}"
             form action="#{root_path}cron/#{job.name}/delete" method="post"
-              input.btn.btn-danger.btn-small type="submit" name="delete" value="#{no_translation('Delete')}" data-confirm="#{no_translation('AreYouSureDeleteCronJob', :job => job.name)}"
+              input.btn.btn-danger.btn-small type="submit" name="delete" value="#{no_translation('Delete')}" data-confirm="#{no_translation('AreYouSureDeleteCronJob')}"
 
 - else
   .alert.alert-success = no_translation('NoCronJobsFound')


### PR DESCRIPTION
11:22:13 web.1     | ArgumentError - wrong number of arguments (2 for 1):
11:22:13 web.1     |    /Users/sqe/.rvm/gems/ruby-2.0.0-p247@sqe/bundler/gems/sidekiq-cron-3eedf97281b3/lib/sidekiq/cron/web_extension.rb:11:in `no_translation'
