### PR TITLE
rescue from all exceptions in poller

### DIFF
--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -34,7 +34,7 @@ module Sidekiq
               end
             end
 
-          rescue => ex
+          rescue Exception => ex
             # Most likely a problem with redis networking.
             # Punt and try again at the next interval
             logger.error ex.message


### PR DESCRIPTION
this is needed to catch an error in rufus-scheduler that results in a stack level too deep error and freezes sidekiq-cron until sidekiq is restarted
