### PR TITLE
Allows @klass for a job to be of a Class instance

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -283,9 +283,19 @@ module Sidekiq
           end
         end
 
-        errors << "'klass' (or class) must be set" if @klass.nil? || @klass.size == 0
+        errors << "'klass' (or class) must be set" unless klass_valid
 
         !errors.any?
+      end
+
+      def klass_valid
+        case @klass
+          when Class
+            true
+          when String
+            @klass.size > 0
+          else
+        end
       end
 
       # add job to cron jobs

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -73,6 +73,13 @@ class CronJobTest < Test::Unit::TestCase
         @job = Sidekiq::Cron::Job.new()
       end
 
+      should "allow a class instance for the klass" do
+        @job.klass = CronTestClass
+
+        refute @job.valid?
+        refute @job.errors.any?{|e| e.include?("klass")}, "Should not have error for klass"
+      end
+
       should "return false on valid? and errors" do
         refute @job.valid?
         assert @job.errors.is_a?(Array)


### PR DESCRIPTION
The code allows for @klass to be a class constant, but the #valid? method assumes that for non-nil @klass that it responds to #size (assuming a String?)  This extracts that logic to klass_valid and allows for the case where @klass is a Class

Adds test case allowing @klass to be a class constant.
