### PR TITLE
Add cleanup removed job methods

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -351,6 +351,14 @@ module Sidekiq
         logger.info { "Cron Jobs - deleted all jobs" }
       end
 
+      # remove "removed jobs" between current jobs and new jobs
+      def self.destroy_removed_jobs new_job_names
+        current_job_names = Sidekiq::Cron::Job.all.map(&:name)
+        removed_job_names = current_job_names - new_job_names
+        removed_job_names.each { |j| Sidekiq::Cron::Job.destroy(j) }
+        removed_job_names
+      end
+
       # Parse cron specification '* * * * *' and returns
       # time when last run should be performed
       def last_time now = Time.now

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -11,7 +11,7 @@ module Sidekiq
       extend Util
 
       #how long we would like to store informations about previous enqueues
-      REMEMBER_THRESHOLD = 24 * 60 * 60 
+      REMEMBER_THRESHOLD = 24 * 60 * 60
 
       #crucial part of whole enquing job
       def should_enque? time
@@ -194,7 +194,7 @@ module Sidekiq
             when String
               begin
                 @klass.constantize.get_sidekiq_options.merge(message_data)
-              rescue 
+              rescue
                 #Unknown class
                 message_data.merge("queue"=>"default")
               end
@@ -211,7 +211,7 @@ module Sidekiq
 
       end
 
-      def status 
+      def status
         @status
       end
 
@@ -258,7 +258,7 @@ module Sidekiq
         }
       end
 
-      def errors 
+      def errors
         @errors ||= []
       end
 
@@ -268,9 +268,9 @@ module Sidekiq
 
         errors << "'name' must be set" if @name.nil? || @name.size == 0
         if @cron.nil? || @cron.size == 0
-          errors << "'cron' must be set" 
+          errors << "'cron' must be set"
         else
-          begin 
+          begin
             cron = Rufus::Scheduler::CronLine.new(@cron)
             cron.next_time(Time.now)
           rescue Exception => e
@@ -325,7 +325,7 @@ module Sidekiq
         end
         logger.info { "Cron Jobs - add job with name: #{@name}" }
       end
-      
+
       # remove job from cron jobs by name
       # input:
       #   first arg: name (string) - name of job (must be same - case sensitive)
@@ -333,7 +333,7 @@ module Sidekiq
         Sidekiq.redis do |conn|
           #delete from set
           conn.srem self.class.jobs_key, redis_key
-          
+
           #delete runned timestamps
           conn.del job_enqueued_key
 
@@ -382,7 +382,7 @@ module Sidekiq
       def not_enqueued_after?(time)
         @last_enqueue_time.nil? || @last_enqueue_time < last_time(time)
       end
-      
+
       # Try parsing inbound args into an array.
       # args from Redis will be encoded JSON;
       # try to load JSON, then failover

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -73,6 +73,12 @@ module Sidekiq
         load_from_array array
       end
 
+      # like to {#load_from_hash}
+      # If exists old jobs in redis but removed from args, destroy old jobs
+      def self.load_from_hash! hash
+        destroy_removed_jobs(hash.keys)
+        load_from_hash(hash)
+      end
 
       # load cron jobs from Array
       # input structure should look like:

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -105,6 +105,13 @@ module Sidekiq
         errors
       end
 
+      # like to {#load_from_array}
+      # If exists old jobs in redis but removed from args, destroy old jobs
+      def self.load_from_array! array
+        job_names = array.map { |job| job["name"] }
+        destroy_removed_jobs(job_names)
+        load_from_array(array)
+      end
 
       # get all cron jobs
       def self.all

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -448,6 +448,28 @@ class CronJobTest < Test::Unit::TestCase
 
     end
 
+    context "destroy_removed_jobs" do
+      setup do
+        args1 = {
+          name: "WillBeErasedJob",
+          cron: "* * * * *",
+          klass: "CronTestClass"
+        }
+        Sidekiq::Cron::Job.create(args1)
+
+        args2 = {
+          name: "ContinueRemainingJob",
+          cron: "* * * * *",
+          klass: "CronTestClass"
+        }
+        Sidekiq::Cron::Job.create(args2)
+      end
+
+      should "be destroied removed job that not exists in args" do
+        assert_equal Sidekiq::Cron::Job.destroy_removed_jobs(["ContinueRemainingJob"]), ["WillBeErasedJob"], "Should be destroyed WillBeErasedJob"
+      end
+    end
+
     context "test of enque" do
       setup do 
         @args = {

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -188,7 +188,7 @@ class CronJobTest < Test::Unit::TestCase
         end
       end
     end
- 
+
     context "cron test" do
       setup do
         @job = Sidekiq::Cron::Job.new()

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -583,6 +583,12 @@ class CronJobTest < Test::Unit::TestCase
           assert_equal Sidekiq::Cron::Job.all.size, 0, "Should have 0 jobs after destroy all"
         end
 
+        should "create new jobs and update old one with same settings with load_from_hash!" do
+          assert_equal Sidekiq::Cron::Job.all.size, 0, "Should have 0 jobs before load"
+          out = Sidekiq::Cron::Job.load_from_hash! @jobs_hash
+          assert_equal out.size, 0, "should have no errors"
+          assert_equal Sidekiq::Cron::Job.all.size, 2, "Should have 2 jobs after load"
+        end
       end
 
       context "from array" do

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -614,6 +614,13 @@ class CronJobTest < Test::Unit::TestCase
           assert_equal out.size, 0, "should have 0 error"
           assert_equal Sidekiq::Cron::Job.all.size, 2, "Should have 2 jobs after load"          
         end
+
+        should "create new jobs and update old one with same settings with load_from_array" do
+          assert_equal Sidekiq::Cron::Job.all.size, 0, "Should have 0 jobs before load"
+          out = Sidekiq::Cron::Job.load_from_array! @jobs_array
+          assert_equal out.size, 0, "should have 0 error"
+          assert_equal Sidekiq::Cron::Job.all.size, 2, "Should have 2 jobs after load"
+        end
       end
     end
   end


### PR DESCRIPTION
When remove or rename jobs from arg of `Sidekiq::Cron::Job#load_from_hash` (or `Sidekiq::Cron::Job#load_from_array`) after stored to redis, old jobs are continue remaining permanently!

# Example 1
```ruby
hash = {
  'job1' => { ... },
  'job2' => { ... },
}

Sidekiq::Cron::Job.load_from_hash hash

Sidekiq::Cron::Job.all.map(&:name)
# => ["job1", "job2"]

# I want to remove job1

hash = {
  'job2' => { ... },
}
Sidekiq::Cron::Job.load_from_hash hash

Sidekiq::Cron::Job.all.map(&:name)
# => ["job1", "job2"]
```

`job1` is removed from hash, but  continue remaining permanently in redis !

# Example 2
```ruby
hash = {
  'old_job1' => { ... },
  'job2' => { ... },
}

Sidekiq::Cron::Job.load_from_hash hash

Sidekiq::Cron::Job.all.map(&:name)
# => ["old_job1", "job2"]

# I want to rename job name (old_job1 -> new_job1)

hash = {
  'new_job1' => { ... },
  'job2' => { ... },
}
Sidekiq::Cron::Job.load_from_hash hash

Sidekiq::Cron::Job.all.map(&:name)
# => ["old_job1", "job2", "new_job1"]
```

Both `old_job1` and `new_job1` is stored in redis !!!

# New Feature
New methods are `Sidekiq::Cron::Job#load_from_hash!` and `Sidekiq::Cron::Job#load_from_array!`

If exists old jobs in redis but removed from `args`, destroy old jobs.

```ruby
hash = {
  'job1' => { ... },
  'job2' => { ... },
}

Sidekiq::Cron::Job.load_from_hash! hash

Sidekiq::Cron::Job.all.map(&:name)
# => ["job1", "job2"]

# I want to remove job1

hash = {
  'job2' => { ... },
}
Sidekiq::Cron::Job.load_from_hash! hash

Sidekiq::Cron::Job.all.map(&:name)
# => ["job2"]
```