### PR TITLE
Disable auto-loading of Sidekiq web-ui-extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Just start sidekiq workers by:
 ### Web Ui for Cron Jobs
 
 If you are using sidekiq web ui and you would like to add cron josb to web too,
-add `require 'sidekiq-cron'` after `require 'sidekiq/web'`.
+add `require 'sidekiq/cron/web'` after `require 'sidekiq/web'`.
 By this you will get:
 ![Web UI](https://github.com/ondrejbartas/sidekiq-cron/raw/master/examples/web-cron-ui.png)
 

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -1,11 +1,4 @@
-begin
-  require "sidekiq/web"
-rescue LoadError
-  # client-only usage
-end
-
 require "sidekiq/cron/job"
-require "sidekiq/cron/web_extension"
 
 #require poller only if celluloid is defined
 if defined?(Celluloid)
@@ -16,16 +9,5 @@ end
 
 module Sidekiq
   module Cron
-  end
-end
-
-if defined?(Sidekiq::Web)
-  Sidekiq::Web.register Sidekiq::Cron::WebExtension
-
-  if Sidekiq::Web.tabs.is_a?(Array)
-    # For sidekiq < 2.5
-    Sidekiq::Web.tabs << "cron"
-  else
-    Sidekiq::Web.tabs["Cron"] = "cron"
   end
 end

--- a/lib/sidekiq/cron/web.rb
+++ b/lib/sidekiq/cron/web.rb
@@ -1,0 +1,12 @@
+require "sidekiq/cron/web_extension"
+
+if defined?(Sidekiq::Web)
+  Sidekiq::Web.register Sidekiq::Cron::WebExtension
+
+  if Sidekiq::Web.tabs.is_a?(Array)
+    # For sidekiq < 2.5
+    Sidekiq::Web.tabs << "cron"
+  else
+    Sidekiq::Web.tabs["Cron"] = "cron"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,7 @@ end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'sidekiq-cron'
+require 'sidekiq/cron/web'
 
 class CronTestClass
   include Sidekiq::Worker


### PR DESCRIPTION
This allows to use sidekiq-cron without the web-ui-integration.

Now you need to explicitly load the cron extension in your routes:
```ruby
require 'sidekiq/web'
require 'sidekiq/cron/web'
mount Sidekiq::Web => '/sidekiq'
```