### PR TITLE
Remove tilt dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'tilt' , '< 2.0.0'
 gem 'sidekiq', '>= 2.17.3'
 gem 'rufus-scheduler', '>= 2.0.24'
 

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -55,7 +55,6 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<tilt>, ["< 2.0.0"])
       s.add_runtime_dependency(%q<sidekiq>, [">= 2.17.3"])
       s.add_runtime_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
@@ -73,7 +72,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<coveralls>, [">= 0"])
       s.add_development_dependency(%q<shotgun>, [">= 0"])
     else
-      s.add_dependency(%q<tilt>, ["< 2.0.0"])
       s.add_dependency(%q<sidekiq>, [">= 2.17.3"])
       s.add_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
       s.add_dependency(%q<bundler>, [">= 0"])
@@ -92,7 +90,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<shotgun>, [">= 0"])
     end
   else
-    s.add_dependency(%q<tilt>, ["< 2.0.0"])
     s.add_dependency(%q<sidekiq>, [">= 2.17.3"])
     s.add_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
     s.add_dependency(%q<bundler>, [">= 0"])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,6 @@ require "mocha/setup"
 
 #SIDEKIQ Require - need to have sidekiq running!
 require 'celluloid/autostart'
-require 'tilt'
 require 'sidekiq'
 require 'sidekiq/util'
 require 'sidekiq/web'


### PR DESCRIPTION
We had a bundler conflict for tilt, `> 2.0.0` vs `2.0.1` so we checked and noticed that Tilt is no longer being used by this gem and can be removed safely.