### PR TITLE
Add description to Job

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -64,9 +64,10 @@ module Sidekiq
       # queue, it createaswrapper arround job
       def active_job_message
         {
-          'class' => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
-          'queue' => @queue,
-          'args'  => [{
+          'class'       => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
+          'queue'       => @queue,
+          'description' => @description,
+          'args'        => [{
             'job_class'  => @klass,
             'job_id'     => SecureRandom.uuid,
             'queue_name' => @queue,
@@ -79,9 +80,10 @@ module Sidekiq
       # input structure should look like:
       # {
       #   'name_of_job' => {
-      #     'class' => 'MyClass',
-      #     'cron'  => '1 * * * *',
-      #     'args'  => '(OPTIONAL) [Array or Hash]'
+      #     'class'       => 'MyClass',
+      #     'cron'        => '1 * * * *',
+      #     'args'        => '(OPTIONAL) [Array or Hash]',
+      #     'description' => '(OPTIONAL) Description of job'
       #   },
       #   'My super iber cool job' => {
       #     'class' => 'SecondClass',
@@ -108,10 +110,11 @@ module Sidekiq
       # input structure should look like:
       # [
       #   {
-      #     'name'  => 'name_of_job',
-      #     'class' => 'MyClass',
-      #     'cron'  => '1 * * * *',
-      #     'args'  => '(OPTIONAL) [Array or Hash]'
+      #     'name'        => 'name_of_job',
+      #     'class'       => 'MyClass',
+      #     'cron'        => '1 * * * *',
+      #     'args'        => '(OPTIONAL) [Array or Hash]',
+      #     'description' => '(OPTIONAL) Description of job'
       #   },
       #   {
       #     'name'  => 'Cool Job for Second Class',
@@ -190,7 +193,7 @@ module Sidekiq
         end
       end
 
-      attr_accessor :name, :cron, :klass, :args, :message
+      attr_accessor :name, :cron, :description, :klass, :args, :message
       attr_reader   :last_enqueue_time
 
       def initialize input_args = {}
@@ -198,6 +201,7 @@ module Sidekiq
 
         @name = args["name"]
         @cron = args["cron"]
+        @description = args["description"] if args["description"]
 
         #get class from klass or class
         @klass = args["klass"] || args["class"]
@@ -294,6 +298,7 @@ module Sidekiq
           name: @name,
           klass: @klass,
           cron: @cron,
+          description: @description,
           args: @args.is_a?(String) ? @args : Sidekiq.dump_json(@args || []),
           message: @message.is_a?(String) ? @message : Sidekiq.dump_json(@message || {}),
           status: @status,

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -116,7 +116,7 @@ describe "Cron Job" do
     end
 
     it "have to_hash method" do
-      [:name,:klass,:cron,:args,:message,:status].each do |key|
+      [:name,:klass,:cron,:description,:args,:message,:status].each do |key|
         assert @job.to_hash.has_key?(key), "to_hash must have key: #{key}"
       end
     end
@@ -244,9 +244,10 @@ describe "Cron Job" do
 
     it 'should return valid payload for Sidekiq::Client' do
       payload = {
-        'class' => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
-        'queue' => 'super_queue',
-        'args'  =>[{
+        'class'       => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
+        'queue'       => 'super_queue',
+        'description' => nil,
+        'args'        => [{
           'job_class'  => 'CronTestClass',
           'job_id'     => 'XYZ',
           'queue_name' => 'super_queue',


### PR DESCRIPTION
Added a description key to job definition which could be very useful in some cases. For instance, [resque-scheduler](https://github.com/resque/resque-scheduler) already has such key