### PR TITLE
Use new poll_interval_average option

### DIFF
--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -48,7 +48,7 @@ module Sidekiq
       private
 
       def poll_interval
-        Sidekiq.options[:poll_interval] || POLL_INTERVAL
+        Sidekiq.options[:poll_interval_average] || Sidekiq.options[:poll_interval] || POLL_INTERVAL
       end
 
       def add_jitter


### PR DESCRIPTION
Poll interval has been deprecated and the option removed

https://github.com/mperham/sidekiq/commit/4255aaf0
and
https://github.com/mperham/sidekiq/commit/b5ab9c9f