### PR TITLE
Ensure time format

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -409,7 +409,7 @@ module Sidekiq
       end
 
       def formated_last_time now = Time.now
-        last_time(now).getutc
+        last_time(now).getutc.iso8601
       end
 
       def self.exists? name


### PR DESCRIPTION
Ensure that `Sidekiq::Cron::Job#formated_last_time` returns the time in
an expected time format. Otherwise, configurations that override the
Ruby/Rails default time format can lead to jobs never being added to the
queue.