### PR TITLE
Avoid displaying jobs when starting console

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ second_job:
 #initializers/sidekiq.rb
 schedule_file = "config/schedule.yml"
 
-if File.exists?(schedule_file)
+if File.exists?(schedule_file) && Sidekiq.server?
   Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
 end
 ```


### PR DESCRIPTION
This fixes the problem I mentioned in #71