### PR TITLE
Sidekiq 4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'sidekiq', '>= 4.0.0.pre2'
+gem 'sidekiq', '>= 4.0.0'
 gem 'rufus-scheduler', '>= 2.0.24'
+gem 'redis-namespace', '>= 1.5.2'
 
 group :development do
   gem 'bundler'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'sidekiq', '>= 2.17.3'
+gem 'sidekiq', '>= 4.0.0.pre2'
 gem 'rufus-scheduler', '>= 2.0.24'
 
 group :development do

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -1,11 +1,6 @@
 require "sidekiq/cron/job"
-
-#require poller only if celluloid is defined
-if defined?(Celluloid)
-  require 'celluloid/autostart'
-  require "sidekiq/cron/poller"
-  require "sidekiq/cron/launcher"
-end
+require "sidekiq/cron/poller"
+require "sidekiq/cron/launcher"
 
 module Sidekiq
   module Cron

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -1,6 +1,5 @@
 require 'sidekiq'
 require 'sidekiq/util'
-require 'sidekiq/actor'
 require 'rufus-scheduler'
 
 module Sidekiq
@@ -271,11 +270,11 @@ module Sidekiq
         @status = "enabled"
         save
       end
-      
+
       def enabled?
         @status == "enabled"
       end
-      
+
       def disabled?
         !enabled?
       end

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -1,7 +1,7 @@
-#require  Sidekiq original launcher
+# require  Sidekiq original launcher
 require 'sidekiq/launcher'
 
-#require cron poller
+# require cron poller
 require 'sidekiq/cron/poller'
 
 # For Cron we need to add some methods to Launcher
@@ -11,39 +11,43 @@ require 'sidekiq/cron/poller'
 # adding start and stop commands to launcher
 module Sidekiq
   class Launcher
-
-    #Add cron poller to launcher
+    # Add cron poller to launcher
     attr_reader :cron_poller
 
-
-    #remember old initialize
+    # remember old initialize
     alias_method :old_initialize, :initialize
 
-    #add cron poller and execute normal initialize of Sidekiq launcher
+    # add cron poller and execute normal initialize of Sidekiq launcher
     def initialize(options)
-      @cron_poller  = Sidekiq::Cron::Poller.new
+      @cron_poller = Sidekiq::Cron::Poller.new
       old_initialize options
     end
 
-
-    #remember old run
+    # remember old run
     alias_method :old_run, :run
 
-    #execute normal run of launcher and run cron poller
+    # execute normal run of launcher and run cron poller
     def run
       old_run
-      cron_poller.async.poll(true)
+      cron_poller.start
     end
 
+    # remember old quiet
+    alias_method :old_quiet, :quiet
 
-    #remember old stop
+    # execute normal quiet of launcher and quiet cron poller
+    def quiet
+      cron_poller.terminate
+      old_quiet
+    end
+
+    # remember old stop
     alias_method :old_stop, :stop
 
-    #execute normal stop of launcher and stop cron poller
+    # execute normal stop of launcher and stop cron poller
     def stop
-      cron_poller.async.terminate if poller.alive?
+      cron_poller.terminate
       old_stop
     end
-
   end
 end

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -1,65 +1,32 @@
 require 'sidekiq'
 require 'sidekiq/util'
-require 'sidekiq/actor'
 require 'sidekiq/cron'
+require 'sidekiq/scheduled'
 
 module Sidekiq
   module Cron
-
-    POLL_INTERVAL = 10
-
-    ##
     # The Poller checks Redis every N seconds for sheduled cron jobs
-    class Poller
-      include Util
-      include Actor
-
-      def poll(first_time=false)
-        watchdog('scheduling cron poller thread died!') do
-          add_jitter if first_time
-
-          begin
-            time_now = Time.now
-
-            #go through all jobs
-            Sidekiq::Cron::Job.all.each do |job|
-              #test if job should be enequed
-              # if yes add job to queue
-              begin
-                job.test_and_enque_for_time! time_now if job && job.valid?
-              rescue => ex
-                #problem somewhere in one job
-                logger.error "CRON JOB: #{ex.message}"
-                logger.error "CRON JOB: #{ex.backtrace.first}"
-              end
-            end
-
-          rescue Exception => ex
-            # Most likely a problem with redis networking.
-            # Punt and try again at the next interval
-            logger.error ex.message
-            logger.error ex.backtrace.first
-          end
-
-          after(poll_interval) { poll }
+    class Poller < Sidekiq::Scheduled::Poller
+      def enqueue
+        Sidekiq::Cron::Job.all.each do |job|
+          enqueue_job(job)
         end
+      rescue => ex
+        # Most likely a problem with redis networking.
+        # Punt and try again at the next interval
+        logger.error ex.message
+        logger.error ex.backtrace.first
       end
 
       private
 
-      def poll_interval
-        Sidekiq.options[:poll_interval_average] || Sidekiq.options[:poll_interval] || POLL_INTERVAL
+      def enqueue_job(job)
+        job.test_and_enque_for_time! Time.now if job && job.valid?
+      rescue => ex
+        # problem somewhere in one job
+        logger.error "CRON JOB: #{ex.message}"
+        logger.error "CRON JOB: #{ex.backtrace.first}"
       end
-
-      def add_jitter
-        begin
-          sleep(poll_interval * rand)
-        rescue Celluloid::Task::TerminatedError
-          # Hit Ctrl-C when Sidekiq is finished booting and we have a chance
-          # to get here.
-        end
-      end
-
     end
   end
 end

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<sidekiq>, [">= 2.17.3"])
+      s.add_runtime_dependency(%q<sidekiq>, [">= 4.0.0"])
       s.add_runtime_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<simplecov>, [">= 0"])
@@ -72,7 +72,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<coveralls>, [">= 0"])
       s.add_development_dependency(%q<shotgun>, [">= 0"])
     else
-      s.add_dependency(%q<sidekiq>, [">= 2.17.3"])
+      s.add_dependency(%q<sidekiq>, [">= 4.0.0"])
       s.add_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
       s.add_dependency(%q<bundler>, [">= 0"])
       s.add_dependency(%q<simplecov>, [">= 0"])
@@ -90,7 +90,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<shotgun>, [">= 0"])
     end
   else
-    s.add_dependency(%q<sidekiq>, [">= 2.17.3"])
+    s.add_dependency(%q<sidekiq>, [">= 4.0.0"])
     s.add_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
     s.add_dependency(%q<bundler>, [">= 0"])
     s.add_dependency(%q<simplecov>, [">= 0"])
@@ -108,4 +108,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<shotgun>, [">= 0"])
   end
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,6 @@ require "rack/test"
 require "mocha/setup"
 
 #SIDEKIQ Require - need to have sidekiq running!
-require 'celluloid/autostart'
 require 'sidekiq'
 require 'sidekiq/util'
 require 'sidekiq/web'

--- a/test/unit/poller_test.rb
+++ b/test/unit/poller_test.rb
@@ -24,12 +24,7 @@ describe 'Cron Poller' do
     }
     @args2 = @args.merge(name: 'with_queue', klass: 'CronTestClassWithQueue', cron: "*/10 * * * *")
 
-    Celluloid.boot
     @poller = Sidekiq::Cron::Poller.new
-  end
-
-  after do
-    Celluloid.shutdown
   end
 
   it 'not enqueue any job - new jobs' do
@@ -40,7 +35,7 @@ describe 'Cron Poller' do
     Sidekiq::Cron::Job.create(@args)
     Sidekiq::Cron::Job.create(@args2)
 
-    @poller.poll
+    @poller.enqueue
 
     Sidekiq.redis do |conn|
       assert_equal 0, conn.llen("queue:default")
@@ -50,7 +45,7 @@ describe 'Cron Poller' do
     #30 seconds after!
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 5, 30)
     Time.stubs(:now).returns(enqueued_time)
-      @poller.poll
+      @poller.enqueue
 
       Sidekiq.redis do |conn|
         assert_equal 0, conn.llen("queue:default")
@@ -66,7 +61,7 @@ describe 'Cron Poller' do
     Sidekiq::Cron::Job.create(@args)
     Sidekiq::Cron::Job.create(@args2)
 
-    @poller.poll
+    @poller.enqueue
 
     Sidekiq.redis do |conn|
       assert_equal 0, conn.llen("queue:default")
@@ -75,7 +70,7 @@ describe 'Cron Poller' do
 
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 6, 1)
     Time.stubs(:now).returns(enqueued_time)
-    @poller.poll
+    @poller.enqueue
 
     Sidekiq.redis do |conn|
       assert_equal 1, conn.llen("queue:default")
@@ -91,7 +86,7 @@ describe 'Cron Poller' do
     Sidekiq::Cron::Job.create(@args)
     Sidekiq::Cron::Job.create(@args2)
 
-    @poller.poll
+    @poller.enqueue
 
     Sidekiq.redis do |conn|
       assert_equal 0, conn.llen("queue:default")
@@ -100,7 +95,7 @@ describe 'Cron Poller' do
 
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 10, 5)
     Time.stubs(:now).returns(enqueued_time)
-    @poller.poll
+    @poller.enqueue
 
     Sidekiq.redis do |conn|
       assert_equal 1, conn.llen("queue:default")
@@ -116,7 +111,7 @@ describe 'Cron Poller' do
     Sidekiq::Cron::Job.create(@args)
     Sidekiq::Cron::Job.create(@args2)
 
-    @poller.poll
+    @poller.enqueue
 
     Sidekiq.redis do |conn|
       assert_equal 0, conn.llen("queue:default")
@@ -125,7 +120,7 @@ describe 'Cron Poller' do
 
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 1)
     Time.stubs(:now).returns(enqueued_time)
-    @poller.poll false
+    @poller.enqueue
     Sidekiq.redis do |conn|
       assert_equal 1, conn.llen("queue:default")
       assert_equal 1, conn.llen("queue:super")
@@ -133,7 +128,7 @@ describe 'Cron Poller' do
 
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 2)
     Time.stubs(:now).returns(enqueued_time)
-    @poller.poll false
+    @poller.enqueue
     Sidekiq.redis do |conn|
       assert_equal 1, conn.llen("queue:default")
       assert_equal 1, conn.llen("queue:super")
@@ -141,7 +136,7 @@ describe 'Cron Poller' do
 
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 20)
     Time.stubs(:now).returns(enqueued_time)
-    @poller.poll false
+    @poller.enqueue
     Sidekiq.redis do |conn|
       assert_equal 1, conn.llen("queue:default")
       assert_equal 1, conn.llen("queue:super")
@@ -149,7 +144,7 @@ describe 'Cron Poller' do
 
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 50)
     Time.stubs(:now).returns(enqueued_time)
-    @poller.poll false
+    @poller.enqueue
     Sidekiq.redis do |conn|
       assert_equal 1, conn.llen("queue:default")
       assert_equal 1, conn.llen("queue:super")


### PR DESCRIPTION
I've refactored the poller to work with the recent Sidekiq 4 changes. It is now inheriting from the Sidekiq poller which makes it more straightforward. Its possible that sidekiq changes could break it in the future, but I thought this would be better than duplicating the logic, especially since the gem is already pretty heavily dependent on the Sidekiq classes.

This drops support for prior versions of Sidekiq. I didn't have any ideas for a clean way to support them with the difference in dependencies. This update could be released as a major version and only support Sidekiq 4 going forward. Otherwise let me know how you'd like to support them both.