### PR TITLE
job.enque! should not raise exception when class is unknown

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -44,7 +44,13 @@ module Sidekiq
       def enque! time = Time.now
         @last_enqueue_time = time
 
-        klass_const = @klass.to_s.constantize rescue nil
+        klass_const =
+            begin
+              @klass.to_s.constantize
+            rescue NameError
+              nil
+            end
+
         if @active_job or defined?(ActiveJob::Base) && klass_const && klass_const < ActiveJob::Base
           Sidekiq::Client.push(active_job_message)
         else

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -44,7 +44,8 @@ module Sidekiq
       def enque! time = Time.now
         @last_enqueue_time = time
 
-        if @active_job or defined?(ActiveJob::Base) && @klass.to_s.constantize < ActiveJob::Base
+        klass_const = @klass.to_s.constantize rescue nil
+        if @active_job or defined?(ActiveJob::Base) && klass_const && klass_const < ActiveJob::Base
           Sidekiq::Client.push(active_job_message)
         else
           Sidekiq::Client.push(sidekiq_worker_message)

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -494,6 +494,23 @@ describe "Cron Job" do
         @job.enque!
       end
     end
+
+    describe 'sidekiq worker unknown class' do
+      before do
+        @args = {
+          name:  'Test',
+          cron:  '* * * * *',
+          klass: 'UnknownClass',
+          queue: 'another'
+        }
+        @job = Sidekiq::Cron::Job.new(@args)
+      end
+
+      it 'pushes to queue sidekiq worker message' do
+        assert_equal @job.sidekiq_worker_message, { 'class' => 'UnknownClass', 'args' => [], 'queue' => 'another' }
+        @job.enque!
+      end
+    end
   end
 
   describe "save" do


### PR DESCRIPTION
We are running sidekiq-cron in an environment where it should enqueue jobs whose class definition exists outside of its own codebase. Sidekiq workers running on a remote host will read this queue and perform the jobs.

The ActiveJob check tries to constantize the class name, then raises an exception if the class doesn't exist. (If you agree) I think the job definition should still be enqueued, and class lookups should be resolved by the workers instead of by sidekiq-cron