### PR TITLE
Permit to use ActiveJob::Base.queue_name_delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ _Job properties_:
  'queue' => 'name of queue',
  'args'  => '[Array or Hash] of arguments which will be passed to perform method',
  'active_job' => true,  # enqueue job through rails 4.2+ active job interface
- 'queue_name_prefix' => 'prefix' # rails 4.2+ active job queue with prefix
+ 'queue_name_prefix' => 'prefix', # rails 4.2+ active job queue with prefix
+ 'queue_name_delimiter' => '.'  # rails 4.2+ active job queue with custom delimiter
 }
 ```
 


### PR DESCRIPTION
As a user I want to use `sidekiq-cron` in my rails project with custom `ActiveJob.queue_name_delimiter`

The default queue name prefix delimiter is '_'. This can be changed by setting `queue_name_delimiter` 
in Job properties:

```ruby
{
 'name'  => 'name_of_job', #must be uniq!
 'cron'  => '1 * * * *',
 'class' => 'MyClass',
 #OPTIONAL
 'queue' => 'name of queue',
 'args'  => '[Array or Hash] of arguments which will be passed to perform method',
 'active_job' => true,  # enqueue job through rails 4.2+ active job interface
 'queue_name_prefix' => 'prefix' # rails 4.2+ active job queue with prefix
 'queue_name_delimiter' => '.'  # rails 4.2+ active job queue with custom delimiter
}
```
