### PR TITLE
list `redis-namespace` as development dependency

### DIFF
--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<sidekiq>, [">= 4.0.0"])
       s.add_runtime_dependency(%q<rufus-scheduler>, [">= 2.0.24"])
-      s.add_runtime_dependency(%q<redis-namespace>, [">= 1.5.2"])
+      s.add_development_dependency(%q<redis-namespace>, [">= 1.5.2"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_development_dependency(%q<shoulda-context>, [">= 0"])
@@ -111,4 +111,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<shotgun>, [">= 0"])
   end
 end
-


### PR DESCRIPTION
`redis-namespace` gem is not required by `sidekiq` anymore. make this gem a development dependency as only specs rely on it atm

related: #96
