### PR TITLE
Only update the enqueued key on save if there isn't already one

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -414,7 +414,7 @@ module Sidekiq
 
           #add information about last time! - don't enque right after scheduler poller starts!
           time = Time.now
-          conn.zadd(job_enqueued_key, time.to_f.to_s, formated_last_time(time).to_s)
+          conn.zadd(job_enqueued_key, time.to_f.to_s, formated_last_time(time).to_s) unless conn.exists(job_enqueued_key)
         end
         logger.info { "Cron Jobs - add job with name: #{@name}" }
       end

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -835,6 +835,15 @@ describe "Cron Job" do
       refute Sidekiq::Cron::Job.new(@args.merge(cron: "0 1,13 * * *")).should_enque? @time
     end
 
+    it 'doesnt skip enqueuing if job is resaved near next enqueue time' do
+      job = Sidekiq::Cron::Job.new(@args)
+      assert job.test_and_enque_for_time!(@time), "should enqueue"
+
+      Time.stubs(:now).returns(@time + 1 * 60 * 60) # save uses Time.now
+      job.save
+      assert Sidekiq::Cron::Job.new(@args).test_and_enque_for_time!(@time + 1 * 60 * 60 + 30), "should enqueue"
+    end
+
     it "remove old enque times + should be enqeued" do
       job = Sidekiq::Cron::Job.new(@args)
       assert_nil job.last_enqueue_time
@@ -843,7 +852,7 @@ describe "Cron Job" do
 
       refute Sidekiq::Cron::Job.new(@args).test_and_enque_for_time!(@time), "should not enqueue"
       Sidekiq.redis do |conn|
-        assert_equal conn.zcard(Sidekiq::Cron::Job.new(@args).send(:job_enqueued_key)), 2, "Should have two enqueued job (first was in save, second in enque)"
+        assert_equal conn.zcard(Sidekiq::Cron::Job.new(@args).send(:job_enqueued_key)), 1, "Should have one enqueued job"
       end
       assert_equal Sidekiq::Queue.all.first.size, 1, "Sidekiq queue 1 job in queue"
 
@@ -852,7 +861,7 @@ describe "Cron Job" do
       refute Sidekiq::Cron::Job.new(@args).test_and_enque_for_time! @time + 1 * 60 * 60
 
       Sidekiq.redis do |conn|
-        assert_equal conn.zcard(Sidekiq::Cron::Job.new(@args).send(:job_enqueued_key)), 3, "Should have two enqueued job + one from start"
+        assert_equal conn.zcard(Sidekiq::Cron::Job.new(@args).send(:job_enqueued_key)), 2, "Should have two enqueued job"
       end
       assert_equal Sidekiq::Queue.all.first.size, 2, "Sidekiq queue 2 jobs in queue"
 

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -839,9 +839,10 @@ describe "Cron Job" do
       job = Sidekiq::Cron::Job.new(@args)
       assert job.test_and_enque_for_time!(@time), "should enqueue"
 
-      Time.stubs(:now).returns(@time + 1 * 60 * 60) # save uses Time.now
+      future_now = @time + 1 * 60 * 60
+      Time.stubs(:now).returns(future_now) # save uses Time.now
       job.save
-      assert Sidekiq::Cron::Job.new(@args).test_and_enque_for_time!(@time + 1 * 60 * 60 + 30), "should enqueue"
+      assert Sidekiq::Cron::Job.new(@args).test_and_enque_for_time!(future_now + 30), "should enqueue"
     end
 
     it "remove old enque times + should be enqeued" do


### PR DESCRIPTION
I noticed that if a cron job is resaved within ~30 seconds of when it supposed to be enqueued next it won't be enqueued. The resave in my case is a result of the application being restarted and the initializers being triggered. The failure to enqueue appears to be caused by line 417 in job#save. 

I am curious about the need to set the job_enqueued_key on save, but my assumption is so that new jobs aren't immediately queued. Let me know if my assumption is incorrect.

Thanks.