### PR TITLE
[FIX] Fix a tpyo on the cron dashboard for enabling a job

### DIFF
--- a/lib/sidekiq/cron/locales/en.yml
+++ b/lib/sidekiq/cron/locales/en.yml
@@ -6,7 +6,7 @@ en:
   'Cron string': Cron
   AreYouSureDeleteCronJob: Are you sure you want to delete the %{job} cron job?
   NoCronJobsFound: "No cron jobs found"
-  Enable: Enabled
+  Enable: Enable
   Disable: Disable
   'Last enque': Last enqueued
   disabled: disabled


### PR DESCRIPTION
<img width="283" alt="screen shot 2016-08-15 at 12 18 27 am" src="https://cloud.githubusercontent.com/assets/3485060/17658127/1a6a93f6-627e-11e6-8fc9-f5807700cd87.png">

Randomly noticed the above. Button should read "Enable", since it re-enables a job.