### PR TITLE
Fix rufus-scheduler 3.3.0 ZoTime operation bug.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sidekiq', '>= 4.2.1'
-gem 'rufus-scheduler', '>= 2.0.24'
+gem 'rufus-scheduler', '>= 3.3.0'
 gem 'redis-namespace', '>= 1.5.2'
 
 group :development do

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -543,7 +543,7 @@ module Sidekiq
 
       def not_past_scheduled_time?(current_time)
         last_cron_time = Rufus::Scheduler::CronLine.new(@cron).previous_time(current_time)
-        return false if (current_time - last_cron_time) > 60
+        return false if (current_time.to_i - last_cron_time.to_i) > 60
         true
       end
 

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -517,7 +517,7 @@ module Sidekiq
       private
 
       def not_enqueued_after?(time)
-        @last_enqueue_time.nil? || @last_enqueue_time < last_time(time)
+        @last_enqueue_time.nil? || @last_enqueue_time.to_i < last_time(time).to_i
       end
 
       # Try parsing inbound args into an array.


### PR DESCRIPTION
ERROR: CRON JOB: can't convert Rufus::Scheduler::ZoTime into an exact number.