### PR TITLE
Fix poller to not adding all jobs and given period of time

### DIFF
--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -8,8 +8,9 @@ module Sidekiq
     # The Poller checks Redis every N seconds for sheduled cron jobs
     class Poller < Sidekiq::Scheduled::Poller
       def enqueue
+        time = Time.now.utc
         Sidekiq::Cron::Job.all.each do |job|
-          enqueue_job(job)
+          enqueue_job(job, time)
         end
       rescue => ex
         # Most likely a problem with redis networking.
@@ -20,8 +21,8 @@ module Sidekiq
 
       private
 
-      def enqueue_job(job)
-        job.test_and_enque_for_time! Time.now.utc if job && job.valid?
+      def enqueue_job(job, time = Time.now.utc)
+        job.test_and_enque_for_time! time if job && job.valid?
       rescue => ex
         # problem somewhere in one job
         logger.error "CRON JOB: #{ex.message}"


### PR DESCRIPTION
When having lot of jobs to schedule, time can go and 60s window is too small to enqueue them all.
Remember time of poller enqueue and then use it for all jobs