### PR TITLE
MISC #171 - Failed to add cron jobs from schedule.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,10 @@ second_job:
 
 ```ruby
 #initializers/sidekiq.rb
+require 'sidekiq/cli'
 schedule_file = "config/schedule.yml"
 
-if File.exists?(schedule_file) && Sidekiq.server?
+if File.exist?(schedule_file) && Sidekiq.server?
   Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
 end
 ```


### PR DESCRIPTION
- Add require 'sidekiq/cli' into 'schedule.yml'
- 'File.exists?' is deprecated in favor of 'File.exist?'