### PR TITLE
CI against Ruby 2.2.8/2.3.5/2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.1
-  - 2.2.2
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8
 services:
   - redis-server
 branches:


### PR DESCRIPTION
Ruby 2.2.8/2.3.5/2.4.2 has been released

https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/
