### PR TITLE
Prefer ::strptime as it is more explicit and consistent

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -273,7 +273,7 @@ module Sidekiq
 
         #set last enqueue time - from args or from existing job
         if args['last_enqueue_time'] && !args['last_enqueue_time'].empty?
-          @last_enqueue_time = Time.parse(args['last_enqueue_time'])
+          @last_enqueue_time = Time.strptime(args['last_enqueue_time'], '%M/%d/%Y')
         else
           @last_enqueue_time = last_enqueue_time_from_redis
         end
@@ -362,7 +362,7 @@ module Sidekiq
         out = nil
         if fetch_missing_args
           Sidekiq.redis do |conn|
-            out = Time.parse(conn.hget(redis_key, "last_enqueue_time")) rescue nil
+            out = Time.strptime(conn.hget(redis_key, "last_enqueue_time"), '%M/%d/%Y') rescue nil
           end
         end
         out

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -274,7 +274,7 @@ module Sidekiq
 
         #set last enqueue time - from args or from existing job
         if args['last_enqueue_time'] && !args['last_enqueue_time'].empty?
-          @last_enqueue_time = Time.strptime(args['last_enqueue_time'], '%m/%d/%Y')
+          @last_enqueue_time = Time.strptime(args['last_enqueue_time'], '%Y-%m-%d %H:%M:%S')
         else
           @last_enqueue_time = last_enqueue_time_from_redis
         end
@@ -363,7 +363,7 @@ module Sidekiq
         out = nil
         if fetch_missing_args
           Sidekiq.redis do |conn|
-            out = Time.strptime(conn.hget(redis_key, "last_enqueue_time"), '%m/%d/%Y') rescue nil
+            out = Time.strptime(conn.hget(redis_key, "last_enqueue_time"), '%Y-%m-%d %H:%M:%S') rescue nil
           end
         end
         out

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -2,7 +2,6 @@ require 'sidekiq'
 require 'sidekiq/util'
 require 'rufus-scheduler'
 require 'sidekiq/cron/support'
-require 'time'
 
 module Sidekiq
   module Cron

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -273,7 +273,7 @@ module Sidekiq
 
         #set last enqueue time - from args or from existing job
         if args['last_enqueue_time'] && !args['last_enqueue_time'].empty?
-          @last_enqueue_time = Time.strptime(args['last_enqueue_time'], '%M/%d/%Y')
+          @last_enqueue_time = Time.strptime(args['last_enqueue_time'], '%m/%d/%Y')
         else
           @last_enqueue_time = last_enqueue_time_from_redis
         end
@@ -362,7 +362,7 @@ module Sidekiq
         out = nil
         if fetch_missing_args
           Sidekiq.redis do |conn|
-            out = Time.strptime(conn.hget(redis_key, "last_enqueue_time"), '%M/%d/%Y') rescue nil
+            out = Time.strptime(conn.hget(redis_key, "last_enqueue_time"), '%m/%d/%Y') rescue nil
           end
         end
         out

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -2,6 +2,7 @@ require 'sidekiq'
 require 'sidekiq/util'
 require 'rufus-scheduler'
 require 'sidekiq/cron/support'
+require 'time'
 
 module Sidekiq
   module Cron


### PR DESCRIPTION
This replaces `Time.parse` with `Time.strptime`. `strptime` is more explicit and more consistent across Ruby versions. This change should resolve #183.