### PR TITLE
Fix poll interval description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A scheduling add-on for [Sidekiq](http://sidekiq.org).
 
 Runs a thread alongside Sidekiq workers to schedule jobs at specified times (using cron notation `* * * * *` parsed by [Rufus-Scheduler](https://github.com/jmettraux/rufus-scheduler), more about [cron notation](http://www.nncron.ru/help/EN/working/cron-format.htm).
 
-Checks for new jobs to schedule every 10 seconds and doesn't schedule the same job multiple times when more than one Sidekiq worker is running.
+Checks for new jobs to schedule every 30 seconds and doesn't schedule the same job multiple times when more than one Sidekiq worker is running.
 
 Scheduling jobs are added only when at least one Sidekiq process is running, but it is safe to use Sidekiq-Cron in environments where multiple Sidekiq processes or nodes are running.
 


### PR DESCRIPTION
I noticed that the README is outdated :)

The default poll interval is now 30s not 10s.