### PR TITLE
Clarify rufus-scheduler uses Rails timezone in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ _Job properties_:
 For testing your cron notation you can use [crontab.guru](https://crontab.guru).
 
 sidekiq-cron uses [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler) to parse the cronline.
-By default, the timezone this is evaluated against UTC.
+If using Rails, this is evaluated against the timezone configured in Rails, otherwise the default is UTC.
 
 If you want to have your jobs enqueued based on a different time zone you can specify a timezone in the cronline,
 like this `'0 22 * * 1-5 America/Chicago'`.


### PR DESCRIPTION
As of rufus-scheduler v3.3.3 (https://github.com/jmettraux/rufus-scheduler/commit/dc9e9df051b2d9f5379f3cd5c703f078b35b8e3a), the Rails timezone is used by default when Rails is present.