### PR TITLE
Add 'wrapped' argument to ActiveJob message

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -124,6 +124,7 @@ module Sidekiq
       def active_job_message
         {
           'class'        => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
+          'wrapped'      => @klass,
           'queue'        => @queue_name_with_prefix,
           'description'  => @description,
           'args'         => [{

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -299,6 +299,7 @@ describe "Cron Job" do
     it 'should return valid payload for Sidekiq::Client' do
       payload = {
         'class'       => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
+        'wrapped'     => 'ActiveJobCronTestClass',
         'queue'       => 'super_queue',
         'description' => nil,
         'args'        => [{
@@ -330,10 +331,11 @@ describe "Cron Job" do
 
     it 'should return valid payload for Sidekiq::Client' do
       payload = {
-        'class' => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
-        'queue' => 'prefix_super_queue',
+        'class'       => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
+        'wrapped'     => 'ActiveJobCronTestClass',
+        'queue'       => 'prefix_super_queue',
         'description' => nil,
-        'args'  =>[{
+        'args'        => [{
           'job_class'  => 'ActiveJobCronTestClass',
           'job_id'     => 'XYZ',
           'queue_name' => 'prefix_super_queue',


### PR DESCRIPTION
Fixes issue where sidekiq-cron doesn't add the "wrapped" argument that is used by ActiveJob and Sidekiq to determine the original class

Rails has a test for it: https://github.com/rails/rails/blob/9d9f752661c31b3063d55bec14e797c957d2bb7d/activejob/test/integration/queuing_test.rb#L30 

And Sidekiq uses it in their API: https://github.com/mperham/sidekiq/blob/2ed92600fa71a9c275189d01df369ad4f8b9ca32/lib/sidekiq/api.rb#L322

Without the 'wrapped' param it takes the entire "args" class as the job name, causing all kinds of issues. 

