### PR TITLE
Use directly fugit instead of rufus-scheduler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sidekiq', '>= 4.2.1'
-gem 'rufus-scheduler', '>= 3.3.0'
+gem 'fugit', '~> 1.1'
 
 group :development do
   gem 'bundler'

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -5,15 +5,15 @@
 # stub: sidekiq-cron 0.6.3 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "sidekiq-cron"
+  s.name = "sidekiq-cron".freeze
   s.version = "0.6.3"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["Ondrej Bartas"]
-  s.date = "2017-06-20"
-  s.description = "Enables to set jobs to be run in specified time (using CRON notation)"
-  s.email = "ondrej@bartas.cz"
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Ondrej Bartas".freeze]
+  s.date = "2018-05-17"
+  s.description = "Enables to set jobs to be run in specified time (using CRON notation)".freeze
+  s.email = "ondrej@bartas.cz".freeze
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.md"
@@ -37,7 +37,9 @@ Gem::Specification.new do |s|
     "lib/sidekiq/cron/launcher.rb",
     "lib/sidekiq/cron/locales/de.yml",
     "lib/sidekiq/cron/locales/en.yml",
+    "lib/sidekiq/cron/locales/ja.yml",
     "lib/sidekiq/cron/locales/ru.yml",
+    "lib/sidekiq/cron/locales/zh-CN.yml",
     "lib/sidekiq/cron/poller.rb",
     "lib/sidekiq/cron/support.rb",
     "lib/sidekiq/cron/views/cron.erb",
@@ -51,75 +53,75 @@ Gem::Specification.new do |s|
     "test/unit/poller_test.rb",
     "test/unit/web_extension_test.rb"
   ]
-  s.homepage = "http://github.com/ondrejbartas/sidekiq-cron"
-  s.licenses = ["MIT"]
-  s.rubygems_version = "2.5.1"
-  s.summary = "Sidekiq Cron helps to add repeated scheduled jobs"
+  s.homepage = "http://github.com/ondrejbartas/sidekiq-cron".freeze
+  s.licenses = ["MIT".freeze]
+  s.rubygems_version = "2.6.13".freeze
+  s.summary = "Sidekiq Cron helps to add repeated scheduled jobs".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<sidekiq>, [">= 4.2.1"])
-      s.add_runtime_dependency(%q<rufus-scheduler>, [">= 3.3.0"])
-      s.add_development_dependency(%q<bundler>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<redis-namespace>, [">= 1.5.2"])
-      s.add_development_dependency(%q<shoulda-context>, [">= 0"])
-      s.add_development_dependency(%q<rack>, [">= 0"])
-      s.add_development_dependency(%q<rack-test>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
-      s.add_development_dependency(%q<minitest>, [">= 0"])
-      s.add_development_dependency(%q<test-unit>, [">= 0"])
-      s.add_development_dependency(%q<sdoc>, [">= 0"])
-      s.add_development_dependency(%q<slim>, [">= 0"])
-      s.add_development_dependency(%q<sinatra>, [">= 0"])
-      s.add_development_dependency(%q<mocha>, [">= 0"])
-      s.add_development_dependency(%q<coveralls>, [">= 0"])
-      s.add_development_dependency(%q<shotgun>, [">= 0"])
-      s.add_development_dependency(%q<guard>, [">= 0"])
-      s.add_development_dependency(%q<guard-minitest>, [">= 0"])
+      s.add_runtime_dependency(%q<sidekiq>.freeze, [">= 4.2.1"])
+      s.add_runtime_dependency(%q<fugit>.freeze, ["~> 1.1"])
+      s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
+      s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
+      s.add_development_dependency(%q<redis-namespace>.freeze, [">= 1.5.2"])
+      s.add_development_dependency(%q<shoulda-context>.freeze, [">= 0"])
+      s.add_development_dependency(%q<rack>.freeze, [">= 0"])
+      s.add_development_dependency(%q<rack-test>.freeze, [">= 0"])
+      s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
+      s.add_development_dependency(%q<minitest>.freeze, [">= 0"])
+      s.add_development_dependency(%q<test-unit>.freeze, [">= 0"])
+      s.add_development_dependency(%q<sdoc>.freeze, [">= 0"])
+      s.add_development_dependency(%q<slim>.freeze, [">= 0"])
+      s.add_development_dependency(%q<sinatra>.freeze, [">= 0"])
+      s.add_development_dependency(%q<mocha>.freeze, [">= 0"])
+      s.add_development_dependency(%q<coveralls>.freeze, [">= 0"])
+      s.add_development_dependency(%q<shotgun>.freeze, [">= 0"])
+      s.add_development_dependency(%q<guard>.freeze, [">= 0"])
+      s.add_development_dependency(%q<guard-minitest>.freeze, [">= 0"])
     else
-      s.add_dependency(%q<sidekiq>, [">= 4.2.1"])
-      s.add_dependency(%q<rufus-scheduler>, [">= 3.3.0"])
-      s.add_dependency(%q<bundler>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<redis-namespace>, [">= 1.5.2"])
-      s.add_dependency(%q<shoulda-context>, [">= 0"])
-      s.add_dependency(%q<rack>, [">= 0"])
-      s.add_dependency(%q<rack-test>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<minitest>, [">= 0"])
-      s.add_dependency(%q<test-unit>, [">= 0"])
-      s.add_dependency(%q<sdoc>, [">= 0"])
-      s.add_dependency(%q<slim>, [">= 0"])
-      s.add_dependency(%q<sinatra>, [">= 0"])
-      s.add_dependency(%q<mocha>, [">= 0"])
-      s.add_dependency(%q<coveralls>, [">= 0"])
-      s.add_dependency(%q<shotgun>, [">= 0"])
-      s.add_dependency(%q<guard>, [">= 0"])
-      s.add_dependency(%q<guard-minitest>, [">= 0"])
+      s.add_dependency(%q<sidekiq>.freeze, [">= 4.2.1"])
+      s.add_dependency(%q<fugit>.freeze, ["~> 1.1"])
+      s.add_dependency(%q<bundler>.freeze, [">= 0"])
+      s.add_dependency(%q<simplecov>.freeze, [">= 0"])
+      s.add_dependency(%q<redis-namespace>.freeze, [">= 1.5.2"])
+      s.add_dependency(%q<shoulda-context>.freeze, [">= 0"])
+      s.add_dependency(%q<rack>.freeze, [">= 0"])
+      s.add_dependency(%q<rack-test>.freeze, [">= 0"])
+      s.add_dependency(%q<jeweler>.freeze, [">= 0"])
+      s.add_dependency(%q<minitest>.freeze, [">= 0"])
+      s.add_dependency(%q<test-unit>.freeze, [">= 0"])
+      s.add_dependency(%q<sdoc>.freeze, [">= 0"])
+      s.add_dependency(%q<slim>.freeze, [">= 0"])
+      s.add_dependency(%q<sinatra>.freeze, [">= 0"])
+      s.add_dependency(%q<mocha>.freeze, [">= 0"])
+      s.add_dependency(%q<coveralls>.freeze, [">= 0"])
+      s.add_dependency(%q<shotgun>.freeze, [">= 0"])
+      s.add_dependency(%q<guard>.freeze, [">= 0"])
+      s.add_dependency(%q<guard-minitest>.freeze, [">= 0"])
     end
   else
-    s.add_dependency(%q<sidekiq>, [">= 4.2.1"])
-    s.add_dependency(%q<rufus-scheduler>, [">= 3.3.0"])
-    s.add_dependency(%q<bundler>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<redis-namespace>, [">= 1.5.2"])
-    s.add_dependency(%q<shoulda-context>, [">= 0"])
-    s.add_dependency(%q<rack>, [">= 0"])
-    s.add_dependency(%q<rack-test>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<minitest>, [">= 0"])
-    s.add_dependency(%q<test-unit>, [">= 0"])
-    s.add_dependency(%q<sdoc>, [">= 0"])
-    s.add_dependency(%q<slim>, [">= 0"])
-    s.add_dependency(%q<sinatra>, [">= 0"])
-    s.add_dependency(%q<mocha>, [">= 0"])
-    s.add_dependency(%q<coveralls>, [">= 0"])
-    s.add_dependency(%q<shotgun>, [">= 0"])
-    s.add_dependency(%q<guard>, [">= 0"])
-    s.add_dependency(%q<guard-minitest>, [">= 0"])
+    s.add_dependency(%q<sidekiq>.freeze, [">= 4.2.1"])
+    s.add_dependency(%q<fugit>.freeze, ["~> 1.1"])
+    s.add_dependency(%q<bundler>.freeze, [">= 0"])
+    s.add_dependency(%q<simplecov>.freeze, [">= 0"])
+    s.add_dependency(%q<redis-namespace>.freeze, [">= 1.5.2"])
+    s.add_dependency(%q<shoulda-context>.freeze, [">= 0"])
+    s.add_dependency(%q<rack>.freeze, [">= 0"])
+    s.add_dependency(%q<rack-test>.freeze, [">= 0"])
+    s.add_dependency(%q<jeweler>.freeze, [">= 0"])
+    s.add_dependency(%q<minitest>.freeze, [">= 0"])
+    s.add_dependency(%q<test-unit>.freeze, [">= 0"])
+    s.add_dependency(%q<sdoc>.freeze, [">= 0"])
+    s.add_dependency(%q<slim>.freeze, [">= 0"])
+    s.add_dependency(%q<sinatra>.freeze, [">= 0"])
+    s.add_dependency(%q<mocha>.freeze, [">= 0"])
+    s.add_dependency(%q<coveralls>.freeze, [">= 0"])
+    s.add_dependency(%q<shotgun>.freeze, [">= 0"])
+    s.add_dependency(%q<guard>.freeze, [">= 0"])
+    s.add_dependency(%q<guard-minitest>.freeze, [">= 0"])
   end
 end
 

--- a/test/integration/performance_test.rb
+++ b/test/integration/performance_test.rb
@@ -28,8 +28,8 @@ describe 'Performance Poller' do
     end
 
     @poller = Sidekiq::Cron::Poller.new
-    now = Time.now.utc
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 10, 5)
+    now = Time.now.utc + 3600
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 10, 5)
     Time.stubs(:now).returns(enqueued_time)
   end
 

--- a/test/integration/performance_test.rb
+++ b/test/integration/performance_test.rb
@@ -46,7 +46,7 @@ describe 'Performance Poller' do
       assert_equal X, conn.llen("queue:default"), 'Queue should be full'
     end
 
-    puts "Perfomance test finished in #{bench.real}"
+    puts "Performance test finished in #{bench.real}"
     assert_operator bench.real, :<, 30
   end
 end

--- a/test/integration/performance_test.rb
+++ b/test/integration/performance_test.rb
@@ -47,6 +47,6 @@ describe 'Performance Poller' do
     end
 
     puts "Perfomance test finished in #{bench.real}"
-    assert_operator 30, :>, bench.real
+    assert_operator bench.real, :<, 30
   end
 end

--- a/test/integration/performance_test.rb
+++ b/test/integration/performance_test.rb
@@ -2,7 +2,7 @@
 require './test/test_helper'
 require 'benchmark'
 
-describe 'Perfromance Poller' do
+describe 'Performance Poller' do
   X = 10000
   before do
     Sidekiq.redis = REDIS

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -883,7 +883,7 @@ describe "Cron Job" do
         @jobs_hash['name_of_job']['cron'] = "bad cron"
         out = Sidekiq::Cron::Job.load_from_hash @jobs_hash
         assert_equal 1, out.size, "should have 1 error"
-        assert_equal ({"name_of_job"=>["'cron' -> bad cron: not a valid cronline : 'bad cron'"]}), out
+        assert_equal ({"name_of_job"=>["'cron' -> \"bad cron\" -> ArgumentError: not a cron string \"bad cron\""]}), out
         assert_equal 1, Sidekiq::Cron::Job.all.size, "Should have only 1 job after load"
       end
 

--- a/test/unit/poller_test.rb
+++ b/test/unit/poller_test.rb
@@ -45,12 +45,13 @@ describe 'Cron Poller' do
     #30 seconds after!
     enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 5, 30)
     Time.stubs(:now).returns(enqueued_time)
-      @poller.enqueue
 
-      Sidekiq.redis do |conn|
-        assert_equal 0, conn.llen("queue:default")
-        assert_equal 0, conn.llen("queue:super")
-      end
+    @poller.enqueue
+
+    Sidekiq.redis do |conn|
+      assert_equal 0, conn.llen("queue:default")
+      assert_equal 0, conn.llen("queue:super")
+    end
   end
 
   it 'should enqueue only job with cron */2' do

--- a/test/unit/poller_test.rb
+++ b/test/unit/poller_test.rb
@@ -28,8 +28,8 @@ describe 'Cron Poller' do
   end
 
   it 'not enqueue any job - new jobs' do
-    now = Time.now.utc
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 5, 1)
+    now = Time.now.utc + 3600
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 5, 1)
     Time.stubs(:now).returns(enqueued_time)
     #new jobs!
     Sidekiq::Cron::Job.create(@args)
@@ -43,7 +43,7 @@ describe 'Cron Poller' do
     end
 
     #30 seconds after!
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 5, 30)
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 5, 30)
     Time.stubs(:now).returns(enqueued_time)
       @poller.enqueue
 
@@ -54,8 +54,8 @@ describe 'Cron Poller' do
   end
 
   it 'should enqueue only job with cron */2' do
-    now = Time.now.utc
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 5, 1)
+    now = Time.now.utc + 3600
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 5, 1)
     Time.stubs(:now).returns(enqueued_time)
     #new jobs!
     Sidekiq::Cron::Job.create(@args)
@@ -68,7 +68,7 @@ describe 'Cron Poller' do
       assert_equal 0, conn.llen("queue:super")
     end
 
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 6, 1)
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 6, 1)
     Time.stubs(:now).returns(enqueued_time)
     @poller.enqueue
 
@@ -79,8 +79,8 @@ describe 'Cron Poller' do
   end
 
   it 'should enqueue both jobs' do
-    now = Time.now.utc
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 8, 1)
+    now = Time.now.utc + 3600
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 8, 1)
     Time.stubs(:now).returns(enqueued_time)
     #new jobs!
     Sidekiq::Cron::Job.create(@args)
@@ -93,7 +93,7 @@ describe 'Cron Poller' do
       assert_equal 0, conn.llen("queue:super")
     end
 
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 10, 5)
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 10, 5)
     Time.stubs(:now).returns(enqueued_time)
     @poller.enqueue
 
@@ -104,8 +104,8 @@ describe 'Cron Poller' do
   end
 
   it 'should enqueue both jobs but only one time each' do
-    now = Time.now.utc
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 8, 1)
+    now = Time.now.utc + 3600
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 8, 1)
     Time.stubs(:now).returns(enqueued_time)
     #new jobs!
     Sidekiq::Cron::Job.create(@args)
@@ -118,7 +118,7 @@ describe 'Cron Poller' do
       assert_equal 0, conn.llen("queue:super")
     end
 
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 1)
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 20, 1)
     Time.stubs(:now).returns(enqueued_time)
     @poller.enqueue
     Sidekiq.redis do |conn|
@@ -126,7 +126,7 @@ describe 'Cron Poller' do
       assert_equal 1, conn.llen("queue:super")
     end
 
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 2)
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 20, 2)
     Time.stubs(:now).returns(enqueued_time)
     @poller.enqueue
     Sidekiq.redis do |conn|
@@ -134,7 +134,7 @@ describe 'Cron Poller' do
       assert_equal 1, conn.llen("queue:super")
     end
 
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 20)
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 20, 20)
     Time.stubs(:now).returns(enqueued_time)
     @poller.enqueue
     Sidekiq.redis do |conn|
@@ -142,7 +142,7 @@ describe 'Cron Poller' do
       assert_equal 1, conn.llen("queue:super")
     end
 
-    enqueued_time = Time.new(now.year, now.month, now.day, now.hour + 1, 20, 50)
+    enqueued_time = Time.new(now.year, now.month, now.day, now.hour, 20, 50)
     Time.stubs(:now).returns(enqueued_time)
     @poller.enqueue
     Sidekiq.redis do |conn|


### PR DESCRIPTION
Addresses https://github.com/ondrejbartas/sidekiq-cron/issues/199

Sidekiq-cron is not using rufus-scheduler itself but rather its cron logic which recently got spun off in the fugit gem (https://github.com/floraison/fugit).

This patch makes Sidekiq-cron depend directly on fugit instead of rufus-scheduler.

A refinement would be to cache the parsed cron line in the Sidekiq-cron Job instance so that there is no need to reparse each time.

Here is the `rake test` output after patching. Please note that I did not address the remaining five errors, they seem unrelated, out of the scope for this patch :  [test1.txt](https://github.com/ondrejbartas/sidekiq-cron/files/2015048/test1.txt)
