### PR TITLE
Match sidekiq style

### DIFF
--- a/lib/sidekiq/cron/locales/de.yml
+++ b/lib/sidekiq/cron/locales/de.yml
@@ -5,7 +5,7 @@ de:
   EnqueueNow: In Warteschlange
   'Cron string': Cron
   AreYouSureDeleteCronJob: Sind Sie sicher, dass sie den Cronjob %{job} löschen wollen?
-  NoCronJobsFound: "Keine Cronjobs gefunden"
+  NoCronJobsWereFound: Keine Cronjobs gefunden
   Enable: Aktivieren
   Disable: Deaktivieren
   'Last enque': Eingereiht

--- a/lib/sidekiq/cron/locales/en.yml
+++ b/lib/sidekiq/cron/locales/en.yml
@@ -10,7 +10,7 @@ en:
   'Cron string': Cron
   AreYouSureDeleteCronJobs: Are you sure you want to delete ALL cron jobs?
   AreYouSureDeleteCronJob: Are you sure you want to delete the %{job} cron job?
-  NoCronJobsFound: "No cron jobs found"
+  NoCronJobsWereFound: No cron jobs were found
   Enable: Enable
   Disable: Disable
   'Last enque': Last enqueued

--- a/lib/sidekiq/cron/locales/ja.yml
+++ b/lib/sidekiq/cron/locales/ja.yml
@@ -10,7 +10,7 @@ ja:
   'Cron string': Cron
   AreYouSureDeleteCronJobs: 本当にすべてのcronジョブを削除しますか？
   AreYouSureDeleteCronJob: 本当に%{job}のcronジョブを削除しますか？
-  NoCronJobsFound: Cronジョブが見つかりませんでした
+  NoCronJobsWereFound: Cronジョブが見つかりませんでした
   Enable: 有効にする
   Disable: 無効にする
   'Last enque': 最後のキュー

--- a/lib/sidekiq/cron/locales/ru.yml
+++ b/lib/sidekiq/cron/locales/ru.yml
@@ -6,7 +6,7 @@ ru:
   'Cron string': Периодичность (синтаксис Cron)
   EnqueueNow: Запустить
   AreYouSureDeleteCronJob: Вы действительно хотите удалить задачу «%{job}»?
-  NoCronJobsFound: "Не найдено периодических задач"
+  NoCronJobsWereFound: Не найдено периодических задач
   Enable: Включить
   Disable: Отключить
   'Last enque': Последний запуск

--- a/lib/sidekiq/cron/locales/zh-CN.yml
+++ b/lib/sidekiq/cron/locales/zh-CN.yml
@@ -10,7 +10,7 @@ zh-CN:
   'Cron string': 定时策略
   AreYouSureDeleteCronJobs: 你确定删除所有的定时任务吗？
   AreYouSureDeleteCronJob: 你确定删除定时任务（%{job}）吗？
-  NoCronJobsFound: 没有定时任务
+  NoCronJobsWereFound: 没有定时任务
   Enable: 启用
   Disable: 禁用
   'Last enque': 放入队列时间

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -85,6 +85,6 @@
     </tbody>
   </table>
 <% else %>
-  <div class='alert alert-success'><%= t('NoCronJobsFound') %></div>
+  <div class='alert alert-success'><%= t('NoCronJobsWereFound') %></div>
 <% end %>
 

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -3,22 +3,24 @@
     <h3><%=t 'CronJobs' %></h3>
   </div>
   <div class='col-sm-7 pull-right' style="margin-top: 20px; margin-bottom: 10px;">
-    <form action="<%= root_path %>cron/__all__/delete" method="post" class="pull-right">
-      <%= csrf_tag if respond_to?(:csrf_tag) %>
-      <input class="btn btn-small btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>">
-    </form>
-    <form action="<%= root_path %>cron/__all__/disable" method="post" class="pull-right">
-      <%= csrf_tag if respond_to?(:csrf_tag) %>
-      <input class="btn btn-small" type="submit" name="enque" value="<%= t('DisableAll') %>" />
-    </form>
-    <form action="<%= root_path %>cron/__all__/enable" method="post" class="pull-right">
-      <%= csrf_tag if respond_to?(:csrf_tag) %>
-      <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnableAll') %>" />
-    </form>
-    <form action="<%= root_path %>cron/__all__/enque" method="post" class="pull-right">
-      <%= csrf_tag if respond_to?(:csrf_tag) %>
-      <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnqueueAll') %>" />
-    </form>
+    <% if @cron_jobs.size > 0 %>
+      <form action="<%= root_path %>cron/__all__/delete" method="post" class="pull-right">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
+        <input class="btn btn-small btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>">
+      </form>
+      <form action="<%= root_path %>cron/__all__/disable" method="post" class="pull-right">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
+        <input class="btn btn-small" type="submit" name="enque" value="<%= t('DisableAll') %>" />
+      </form>
+      <form action="<%= root_path %>cron/__all__/enable" method="post" class="pull-right">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
+        <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnableAll') %>" />
+      </form>
+      <form action="<%= root_path %>cron/__all__/enque" method="post" class="pull-right">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
+        <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnqueueAll') %>" />
+      </form>
+    <% end %>
   </div>
 </header>
 
@@ -83,6 +85,6 @@
     </tbody>
   </table>
 <% else %>
-  <span class='alert alert-success'><%= t('NoCronJobsFound') %></span>
+  <div class='alert alert-success'><%= t('NoCronJobsFound') %></div>
 <% end %>
 

--- a/lib/sidekiq/cron/views/cron.slim
+++ b/lib/sidekiq/cron/views/cron.slim
@@ -3,18 +3,19 @@ header.row
     h3 = t('CronJobs')
 
   .span.col-sm-7.pull-right style="margin-top: 20px; margin-bottom: 10px;"
-    form.pull-right action="#{root_path}cron/__all__/delete" method="post"
-      = csrf_tag if respond_to?(:csrf_tag)
-      input.btn.btn-small.pull-left.btn-danger type="submit" name="enque" value="#{t('DeleteAll')}" data-confirm="#{t('AreYouSureDeleteCronJobs')}"
-    form.pull-right action="#{root_path}cron/__all__/disable" method="post"
-      = csrf_tag if respond_to?(:csrf_tag)
-      input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('DisableAll')}"
-    form.pull-right action="#{root_path}cron/__all__/enable" method="post"
-      = csrf_tag if respond_to?(:csrf_tag)
-      input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnableAll')}"
-    form.pull-right action="#{root_path}cron/__all__/enque" method="post"
-      = csrf_tag if respond_to?(:csrf_tag)
-      input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueAll')}"
+    - if @cron_jobs.size > 0
+      form.pull-right action="#{root_path}cron/__all__/delete" method="post"
+        = csrf_tag if respond_to?(:csrf_tag)
+        input.btn.btn-small.pull-left.btn-danger type="submit" name="enque" value="#{t('DeleteAll')}" data-confirm="#{t('AreYouSureDeleteCronJobs')}"
+      form.pull-right action="#{root_path}cron/__all__/disable" method="post"
+        = csrf_tag if respond_to?(:csrf_tag)
+        input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('DisableAll')}"
+      form.pull-right action="#{root_path}cron/__all__/enable" method="post"
+        = csrf_tag if respond_to?(:csrf_tag)
+        input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnableAll')}"
+      form.pull-right action="#{root_path}cron/__all__/enque" method="post"
+        = csrf_tag if respond_to?(:csrf_tag)
+        input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueAll')}"
 
 - if @cron_jobs.size > 0
 

--- a/lib/sidekiq/cron/views/cron.slim
+++ b/lib/sidekiq/cron/views/cron.slim
@@ -67,4 +67,4 @@ header.row
               input.btn.btn-danger.btn-small type="submit" name="delete" value="#{t('Delete')}" data-confirm="#{t('AreYouSureDeleteCronJob', :job => job.name)}"
 
 - else
-  .alert.alert-success = t('NoCronJobsFound')
+  .alert.alert-success = t('NoCronJobsWereFound')


### PR DESCRIPTION
Hello!
I made 2 simple changes to the view.
First is the .alert for "No cron jobs found" to **read** and **feel** more like the actual `Sidekiq` by adding the missing 'were' and by making the `.alert` a full size `div` instead of a `span`.

Second, the action buttons are **only** displayed if there are jobs, by adding `<% if @cron_jobs.size > 0 %>` in _erb_ and `- if @cron_jobs.size > 0` in _slim_.
### Before:
![img before](https://drive.google.com/uc?id=1FUp0drCliJHeAgasyObCPzBwK6j6hhc6)
### After:
![img after](https://drive.google.com/uc?id=1EPhdaJgqeaPbaWXv6rvZ2Cklf9hjCnxM)
![img after job present](https://drive.google.com/uc?id=1qvafhEr1Ih9bMaUmqiC2Sj0RDLNAqdAf)
### Original Sidekiq style:
![sidekiq style](https://drive.google.com/uc?id=1Kqyc_VahRQWa_yV34q5yVXU2Vjd_hc6q)
