### PR TITLE
Switch Time.strptime to DateTime.strptime to always parse as UTC

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -275,7 +275,7 @@ module Sidekiq
 
         #set last enqueue time - from args or from existing job
         if args['last_enqueue_time'] && !args['last_enqueue_time'].empty?
-          @last_enqueue_time = DateTime.strptime(args['last_enqueue_time'], LAST_ENQUEUE_TIME_FORMAT)
+          @last_enqueue_time = parse_enqueue_time(args['last_enqueue_time'])
         else
           @last_enqueue_time = last_enqueue_time_from_redis
         end
@@ -364,7 +364,7 @@ module Sidekiq
         out = nil
         if fetch_missing_args
           Sidekiq.redis do |conn|
-            out = DateTime.strptime(conn.hget(redis_key, "last_enqueue_time"), LAST_ENQUEUE_TIME_FORMAT) rescue nil
+            out = parse_enqueue_time(conn.hget(redis_key, "last_enqueue_time")) rescue nil
           end
         end
         out
@@ -548,6 +548,10 @@ module Sidekiq
         else
           [*args]     # cast to string array
         end
+      end
+
+      def parse_enqueue_time(timestamp)
+        DateTime.strptime(timestamp, LAST_ENQUEUE_TIME_FORMAT).to_time.utc
       end
 
       def not_past_scheduled_time?(current_time)

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -275,7 +275,7 @@ module Sidekiq
 
         #set last enqueue time - from args or from existing job
         if args['last_enqueue_time'] && !args['last_enqueue_time'].empty?
-          @last_enqueue_time = Time.strptime(args['last_enqueue_time'], LAST_ENQUEUE_TIME_FORMAT)
+          @last_enqueue_time = DateTime.strptime(args['last_enqueue_time'], LAST_ENQUEUE_TIME_FORMAT)
         else
           @last_enqueue_time = last_enqueue_time_from_redis
         end
@@ -364,7 +364,7 @@ module Sidekiq
         out = nil
         if fetch_missing_args
           Sidekiq.redis do |conn|
-            out = Time.strptime(conn.hget(redis_key, "last_enqueue_time"), LAST_ENQUEUE_TIME_FORMAT) rescue nil
+            out = DateTime.strptime(conn.hget(redis_key, "last_enqueue_time"), LAST_ENQUEUE_TIME_FORMAT) rescue nil
           end
         end
         out

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -601,13 +601,14 @@ describe "Cron Job" do
     it "last_enqueue_time shouldn't be rewritten after save" do
       #adding last_enqueue_time to initialize is only for test purpose
       last_enqueue_time = '2013-01-01 23:59:59'
+      expected_enqueue_time = DateTime.parse(last_enqueue_time).to_time.utc
       Sidekiq::Cron::Job.create(@args.merge('last_enqueue_time' => last_enqueue_time))
       job = Sidekiq::Cron::Job.find(@args)
-      assert_equal job.last_enqueue_time, Time.parse(last_enqueue_time)
+      assert_equal job.last_enqueue_time, expected_enqueue_time
 
       Sidekiq::Cron::Job.create(@args)
       job = Sidekiq::Cron::Job.find(@args)
-      assert_equal job.last_enqueue_time, Time.parse(last_enqueue_time), "after second create should have same time"
+      assert_equal job.last_enqueue_time, expected_enqueue_time, "after second create should have same time"
     end
   end
 


### PR DESCRIPTION
This is alternate implementation of https://github.com/ondrejbartas/sidekiq-cron/pull/209, although I do believe https://github.com/ondrejbartas/sidekiq-cron/pull/209 to be the more correct implementation. Only difference is that this one doesn't require a breaking change.

As far as I can tell `Time.strptime` will use the system time, `DateTime.strptime` will assume the date string is UTC.

Example:
```ruby
irb(main):004:0> LAST_ENQUEUE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
=> "%Y-%m-%d %H:%M:%S"
irb(main):005:0> Time.now
=> 2018-07-16 16:30:47 -0400
irb(main):029:0> ref_time = Time.now.utc
=> 2018-07-16 20:33:44 UTC
irb(main):030:0> time_string = ref_time.strftime(LAST_ENQUEUE_TIME_FORMAT)
=> "2018-07-16 20:33:44"
irb(main):031:0> Time.strptime(time_string, LAST_ENQUEUE_TIME_FORMAT)
=> 2018-07-16 20:33:44 -0400
irb(main):032:0> DateTime.strptime(time_string, LAST_ENQUEUE_TIME_FORMAT)
=> Mon, 16 Jul 2018 20:33:44 +0000
irb(main):033:0> DateTime.strptime(time_string, LAST_ENQUEUE_TIME_FORMAT).to_i
=> 1531773224
irb(main):034:0> Time.strptime(time_string, LAST_ENQUEUE_TIME_FORMAT).to_i
=> 1531787624
irb(main):035:0> ref_time.to_i
=> 1531773224

```