### PR TITLE
Added jid history, just like Sidekiq Enterprise

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -493,6 +493,9 @@ module Sidekiq
           #delete runned timestamps
           conn.del job_enqueued_key
 
+          # delete jid_history
+          conn.del jid_history_key
+
           #delete main job
           conn.del redis_key
         end

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -59,15 +59,15 @@ module Sidekiq
         jid =
           if klass_const
             if defined?(ActiveJob::Base) && klass_const < ActiveJob::Base
-              jid = enqueue_active_job(klass_const).try :provider_job_id
+              enqueue_active_job(klass_const).try :provider_job_id
             else
-              jid = enqueue_sidekiq_worker(klass_const)
+              enqueue_sidekiq_worker(klass_const)
             end
           else
             if @active_job
-              jid = Sidekiq::Client.push(active_job_message)
+              Sidekiq::Client.push(active_job_message)
             else
-              jid = Sidekiq::Client.push(sidekiq_worker_message)
+              Sidekiq::Client.push(sidekiq_worker_message)
             end
           end
 

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -474,11 +474,12 @@ module Sidekiq
           jid: jid,
           enqueued: @last_enqueue_time
         }
+        @history_size ||= Sidekiq.options[:cron_history_size]&.to_i&.-(1)
         Sidekiq.redis do |conn|
           conn.lpush jid_history_key,
                      Sidekiq.dump_json(jid_history)
           # keep only last 10 entries in a fifo manner
-          conn.ltrim jid_history_key, 0, 9
+          conn.ltrim jid_history_key, 0, @history_size || 9
         end
       end
 

--- a/lib/sidekiq/cron/locales/en.yml
+++ b/lib/sidekiq/cron/locales/en.yml
@@ -16,3 +16,4 @@ en:
   'Last enque': Last enqueued
   disabled: disabled
   enabled: enabled
+  NoHistoryWereFound: No history were found

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -39,7 +39,9 @@
         <tr>
           <td style="<%= style %>"><%= t job.status %></td>
           <td style="<%= style %>">
-            <b><%= job.name %></b>
+            <a href="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>">
+              <b><%= job.name %></b>
+            </a>
             <hr style="margin:3px;border:0;">
             <small>
             <% if job.message and job.message.to_s.size > 100 %>

--- a/lib/sidekiq/cron/views/cron.slim
+++ b/lib/sidekiq/cron/views/cron.slim
@@ -33,7 +33,8 @@ header.row
       tr
         td[style="#{style}"]= job.status
         td[style="#{style}"]
-          b job.name
+          a href="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}"
+            b = job.name
           hr style="margin:3px;border:0;"
           small
             - if job.message and job.message.to_s.size > 100

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -80,5 +80,5 @@
     </tbody>
   </table>
 <% else %>
-  <div class='alert alert-success'><%= t('NoHistoryWereFound') %></div>
+  <div class='alert alert-success'><%= t 'NoHistoryWereFound' %></div>
 <% end %>

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -66,14 +66,14 @@
   <table class="table table-hover table-bordered table-striped">
     <thead>
     <tr>
-      <th><%= t 'Last enque' %></th>
+      <th><%= t 'Enqueued' %></th>
       <th><%= t 'JID' %></th>
     </tr>
     </thead>
     <tbody>
     <% @job.jid_history_from_redis.each do |jid_history| %>
       <tr>
-        <td><%= jid_history['last_enqueue_time'] %></td>
+        <td><%= jid_history['enqueued'] %></td>
         <td><%= jid_history['jid'] %></td>
       </tr>
     <% end %>

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -1,0 +1,80 @@
+<header class="row">
+  <div class="span col-sm-5 pull-left">
+    <h3>
+      <%= "#{t('Cron')} #{t('Job')}" %>
+      <small><%= @job.name %></small>
+    </h3>
+  </div>
+  <div class="span col-sm-7 pull-right" style="margin-top: 20px; margin-bottom: 10px;">
+    <% cron_job_path = "#{root_path}cron/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
+    <form action="<%= cron_job_path %>/enque?redirect=<%= cron_job_path %>" class="pull-right" method="post">
+      <%= csrf_tag if respond_to?(:csrf_tag) %>
+      <input class="btn btn-small pull-left" name="enque" type="submit" value="<%= t('EnqueueNow') %>" />
+    </form>
+    <% if @job.status == 'enabled' %>
+      <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
+        <input class="btn btn-small pull-left" name="disable" type="submit" value="<%= t('Disable') %>" />
+      </form>
+    <% else %>
+      <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
+        <input class="btn btn-small pull-left" name="enable" type="submit" value="<%= t('Enable') %>" />
+      </form>
+      <form action="<%= cron_job_path %>/delete" class="pull-right" method="post">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
+        <input class="btn btn-danger btn-small" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
+      </form>
+    <% end %>
+  </div>
+</header>
+
+<table class="table table-bordered table-striped">
+  <tbody>
+  <tr>
+    <th><%= t 'Status' %></th>
+    <td><%= @job.status %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Name' %></th>
+    <td><%= @job.name %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Message' %></th>
+    <td><pre><%= @job.pretty_message %></pre></td>
+  </tr>
+  <tr>
+    <th><%= t 'Cron' %></th>
+    <td><%= @job.cron.gsub(" ", "&nbsp;") %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Last enque' %></th>
+    <td><%= @job.last_enqueue_time ? relative_time(@job.last_enqueue_time) : "-" %></td>
+  </tr>
+  </tbody>
+</table>
+
+<header class="row">
+  <div class="col-sm-12">
+    <h4>
+      <%= t 'History' %>
+    </h4>
+  </div>
+</header>
+
+<table class="table table-hover table-bordered table-striped">
+  <thead>
+  <tr>
+    <th><%= t 'Last enque' %></th>
+    <th><%= t 'JID' %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @job.jid_history_from_redis.each do |jid_history| %>
+    <tr>
+      <td><%= jid_history['last_enqueue_time'] %></td>
+      <td><%= jid_history['jid'] %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -62,19 +62,23 @@
   </div>
 </header>
 
-<table class="table table-hover table-bordered table-striped">
-  <thead>
-  <tr>
-    <th><%= t 'Last enque' %></th>
-    <th><%= t 'JID' %></th>
-  </tr>
-  </thead>
-  <tbody>
-  <% @job.jid_history_from_redis.each do |jid_history| %>
+<% if @job.jid_history_from_redis.size > 0 %>
+  <table class="table table-hover table-bordered table-striped">
+    <thead>
     <tr>
-      <td><%= jid_history['last_enqueue_time'] %></td>
-      <td><%= jid_history['jid'] %></td>
+      <th><%= t 'Last enque' %></th>
+      <th><%= t 'JID' %></th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+    <% @job.jid_history_from_redis.each do |jid_history| %>
+      <tr>
+        <td><%= jid_history['last_enqueue_time'] %></td>
+        <td><%= jid_history['jid'] %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class='alert alert-success'><%= t('NoHistoryWereFound') %></div>
+<% end %>

--- a/lib/sidekiq/cron/views/cron_show.slim
+++ b/lib/sidekiq/cron/views/cron_show.slim
@@ -43,13 +43,16 @@ header.row
   .col-sm-12
     h4= t 'History'
 
-table.table.table-hover.table-bordered.table-striped
-  thead
-    tr
-      th= t 'Last enque'
-      th= t 'JID'
-  tbody
-    - @job.jid_history_from_redis.each do |jid_history|
+- if @job.jid_history_from_redis.size > 0
+  table.table.table-hover.table-bordered.table-striped
+    thead
       tr
-        td= jid_history['last_enqueue_time']
-        td= jid_history['jid']
+        th= t 'Last enque'
+        th= t 'JID'
+    tbody
+      - @job.jid_history_from_redis.each do |jid_history|
+        tr
+          td= jid_history['last_enqueue_time']
+          td= jid_history['jid']
+- else
+  .alert.alert-success= t 'NoHistoryWereFound'

--- a/lib/sidekiq/cron/views/cron_show.slim
+++ b/lib/sidekiq/cron/views/cron_show.slim
@@ -47,12 +47,12 @@ header.row
   table.table.table-hover.table-bordered.table-striped
     thead
       tr
-        th= t 'Last enque'
+        th= t 'Enqueued'
         th= t 'JID'
     tbody
       - @job.jid_history_from_redis.each do |jid_history|
         tr
-          td= jid_history['last_enqueue_time']
+          td= jid_history['enqueued']
           td= jid_history['jid']
 - else
   .alert.alert-success= t 'NoHistoryWereFound'

--- a/lib/sidekiq/cron/views/cron_show.slim
+++ b/lib/sidekiq/cron/views/cron_show.slim
@@ -1,0 +1,55 @@
+header.row
+  .span.col-sm-5.pull-left
+    h3
+      = "#{t('Cron')} #{t('Job')}"
+      small= @job.name
+  .span.col-sm-7.pull-right style=("margin-top: 20px; margin-bottom: 10px;")
+    - cron_job_path = "#{root_path}cron/#{CGI.escape(@job.name).gsub('+', '%20')}"
+    form.pull-right action="#{cron_job_path}/enque?redirect=#{cron_job_path}" method="post"
+      = csrf_tag if respond_to?(:csrf_tag)
+      input.btn.btn-small.pull-left name="enque" type="submit" value="#{t('EnqueueNow')}"
+    - if @job.status == 'enabled'
+      form.pull-right action="#{cron_job_path}/disable?redirect=#{cron_job_path}" method="post"
+        = csrf_tag if respond_to?(:csrf_tag)
+        input.btn.btn-small.pull-left name="disable" type="submit" value="#{t('Disable')}"
+    - else
+      form.pull-right action="#{cron_job_path}/enable?redirect=#{cron_job_path}" method="post"
+        = csrf_tag if respond_to?(:csrf_tag)
+        input.btn.btn-small.pull-left name="enable" type="submit" value="#{t('Enable')}"
+      form.pull-right action="#{cron_job_path}/delete" method="post"
+        = csrf_tag if respond_to?(:csrf_tag)
+        input.btn.btn-danger.btn-small data-confirm="#{t('AreYouSureDeleteCronJob' job =@job.name)}" name="delete" type="submit" value="#{t('Delete')}" /
+
+table.table.table-bordered.table-striped
+  tbody
+    tr
+      th= t 'Status'
+      td= @job.status
+    tr
+      th= t 'Name'
+      td= @job.name
+    tr
+      th= t 'Message'
+      td
+        pre= @job.pretty_message
+    tr
+      th= t 'Cron'
+      td= @job.cron.gsub(" ", "&nbsp;")
+    tr
+      th= t 'Last enque'
+      td= @job.last_enqueue_time ? relative_time(@job.last_enqueue_time) : "-"
+
+header.row
+  .col-sm-12
+    h4= t 'History'
+
+table.table.table-hover.table-bordered.table-striped
+  thead
+    tr
+      th= t 'Last enque'
+      th= t 'JID'
+  tbody
+    - @job.jid_history_from_redis.each do |jid_history|
+      tr
+        td= jid_history['last_enqueue_time']
+        td= jid_history['jid']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,13 @@ end
 
 module ActiveJob
   class Base
+    attr_accessor *%i[job_class provider_job_id queue_name arguments]
+
+    def initialize
+      yield self if block_given?
+      self.provider_job_id ||= SecureRandom.hex(12)
+    end
+
     def self.queue_name_prefix
       @queue_name_prefix
     end
@@ -81,11 +88,11 @@ module ActiveJob
     end
 
     def self.perform_later(*args)
-      {
-        "job_class"  => self.class.name,
-        "queue_name" => @queue,
-        "args"  => [*args],
-      }
+      new do |instance|
+        instance.job_class = self.class.name
+        instance.queue_name = @queue
+        instance.arguments = [*args]
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,6 +87,10 @@ module ActiveJob
       self
     end
 
+    def try(method, *args, &block)
+      send method, *args, &block if respond_to? method
+    end
+
     def self.perform_later(*args)
       new do |instance|
         instance.job_class = self.class.name

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -359,7 +359,7 @@ describe "Cron Job" do
 
       it 'pushes to queue active jobs message' do
         @job.expects(:enqueue_active_job)
-            .returns(true)
+            .returns(ActiveJobCronTestClass.new)
         @job.enque!
       end
     end
@@ -377,7 +377,7 @@ describe "Cron Job" do
 
       it 'pushes to queue active jobs message with queue_name_prefix' do
         @job.expects(:enqueue_active_job)
-            .returns(true)
+            .returns(ActiveJobCronTestClass.new)
         @job.enque!
       end
     end

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -79,6 +79,12 @@ describe 'Cron web' do
       assert last_response.body.include?(jid)
     end
 
+    it 'redirects to cron path when name not found' do
+      get '/cron/some-fake-name'
+
+      assert_match %r{\/cron\z}, last_response['Location']
+    end
+
     it "disable and enable all cron jobs" do
       post "/cron/__all__/disable"
       assert_equal Sidekiq::Cron::Job.find(@name).status, "disabled"

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -70,11 +70,11 @@ describe 'Cron web' do
       @job.enque!
       get "/cron/#{@name}"
 
-      jid = nil
-      Sidekiq.redis do |conn|
-        history = conn.lrange Sidekiq::Cron::Job.jid_history_key(@name), 0, -1
-        jid = Sidekiq.load_json(history.last)['jid']
-      end
+      jid =
+        Sidekiq.redis do |conn|
+          history = conn.lrange Sidekiq::Cron::Job.jid_history_key(@name), 0, -1
+          Sidekiq.load_json(history.last)['jid']
+        end
 
       assert last_response.body.include?(jid)
     end


### PR DESCRIPTION
I have added the enqueue time/jid history for the cron jobs. This feature is also present in _Sidekiq Ent_.
This will be quite a useful feature.
The default history size will be 10. User can also change it by adding `:cron_history_size` in their `sidekiq.yml` file.

**Have a look:**
![image](https://user-images.githubusercontent.com/2811408/42814798-6d387540-89d6-11e8-8766-fd9ef7f8fe9c.png)
