### PR TITLE
Support timezones in version 1.0.0

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -12,7 +12,7 @@ module Sidekiq
 
       #how long we would like to store informations about previous enqueues
       REMEMBER_THRESHOLD = 24 * 60 * 60
-      LAST_ENQUEUE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
+      LAST_ENQUEUE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S %z'
 
       #crucial part of whole enquing job
       def should_enque? time

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -600,7 +600,7 @@ describe "Cron Job" do
 
     it "last_enqueue_time shouldn't be rewritten after save" do
       #adding last_enqueue_time to initialize is only for test purpose
-      last_enqueue_time = '2013-01-01 23:59:59'
+      last_enqueue_time = '2013-01-01 23:59:59 -0000'
       Sidekiq::Cron::Job.create(@args.merge('last_enqueue_time' => last_enqueue_time))
       job = Sidekiq::Cron::Job.find(@args)
       assert_equal job.last_enqueue_time, Time.parse(last_enqueue_time)


### PR DESCRIPTION
A had a problem running sidekiq-cron on my development machine because I was located in EST time zone, while the sidekiq-cron stored my time as UTC but parsed it as EST, causing a "Last enqueued" date in the future, like this:
![image](https://user-images.githubusercontent.com/15860699/42891609-bd2c63c0-8a7d-11e8-97df-47ba67361bda.png)

This meant that the cron job that should have been running once every minute was actually running once every 4 hours.

Before the change:
```ruby
[17] pry(main)> Sidekiq::Cron::Job.all
=> [#<Sidekiq::Cron::Job:0x00007feb6e3f1d60
  @active_job=false,
  @active_job_queue_name_delimiter="",
  @active_job_queue_name_prefix="",
  @args=[],
  @cron="* * * * *",
  @description="",
  @fetch_missing_args=false,
  @klass="GithubTokenRefresherJob",
  @last_enqueue_time=2018-07-18 14:38:32 -0400,
  @message="{\"retry\":true,\"queue\":\"default\",\"class\":\"GithubTokenRefresherJob\",\"args\":[]}",
  @name="github_token_refresher_job",
  @queue="default",
  @queue_name_with_prefix="default",
  @status="enabled">]
```
Notice that `last_enqueue_time` contained wrong timezone info, it was 10:38AM at EST timezone, which is 14:38 in UTC, but it stores the timezone as EST, which is the problem.

After the change:
```ruby
[6] pry(main)> Sidekiq::Cron::Job.all
=> [#<Sidekiq::Cron::Job:0x00007f8a30e76410
  @active_job=false,
  @active_job_queue_name_delimiter="",
  @active_job_queue_name_prefix="",
  @args=[],
  @cron="* * * * *",
  @description="",
  @fetch_missing_args=false,
  @klass="GithubTokenRefresherJob",
  @last_enqueue_time=2018-07-18 14:40:22 +0000,
  @message="{\"retry\":true,\"queue\":\"default\",\"class\":\"GithubTokenRefresherJob\",\"args\":[]}",
  @name="github_token_refresher_job",
  @queue="default",
  @queue_name_with_prefix="default",
  @status="enabled">]
```
Notice that `last_enqueue_time` now has the correct timezone. I ran this in my local environment, and it seems to work as intended.