### PR TITLE
add date_as_argument job new property

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ _Job properties_:
  #OPTIONAL
  'queue' => 'name of queue',
  'args'  => '[Array or Hash] of arguments which will be passed to perform method',
+ 'date_as_argument' => true, # add the time of execution as last argument of the perform method
  'active_job' => true,  # enqueue job through rails 4.2+ active job interface
  'queue_name_prefix' => 'prefix', # rails 4.2+ active job queue with prefix
  'queue_name_delimiter' => '.'  # rails 4.2+ active job queue with custom delimiter

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -281,6 +281,7 @@ module Sidekiq
 
         #get right arguments for job
         @args = args["args"].nil? ? [] : parse_args( args["args"] )
+        @args += [Time.now.to_f] if args["date_as_argument"]
 
         @active_job = args["active_job"] == true || ("#{args["active_job"]}" =~ (/^(true|t|yes|y|1)$/i)) == 0 || false
         @active_job_queue_name_prefix = args["queue_name_prefix"]

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -223,6 +223,34 @@ describe "Cron Job" do
                                  "class"=>"CronTestClassWithQueue",
                                  "args"=>[]}
     end
+
+    it "be initialized with 'class' and date_as_argument" do
+      job = Sidekiq::Cron::Job.new('class' => 'CronTestClassWithQueue', "date_as_argument" => true)
+
+      job_message = job.message
+      job_args    = job_message.delete("args")
+      assert_equal job_message, {"retry"=>false,
+                                 "queue"=>:super,
+                                 "backtrace"=>true,
+                                 "class"=>"CronTestClassWithQueue"}
+      assert job_args[-1].is_a?(Float)
+      assert job_args[-1].between?(Time.now.to_f - 1, Time.now.to_f)
+    end
+
+    it "be initialized with 'class', 2 arguments and date_as_argument" do
+      job = Sidekiq::Cron::Job.new('class' => 'CronTestClassWithQueue', "date_as_argument" => true, "args"=> ["arg1", :arg2])
+
+      job_message = job.message
+      job_args    = job_message.delete("args")
+      assert_equal job_message, {"retry"=>false,
+                                 "queue"=>:super,
+                                 "backtrace"=>true,
+                                 "class"=>"CronTestClassWithQueue"}
+      assert job_args[-1].is_a?(Float)
+      assert job_args[-1].between?(Time.now.to_f - 1, Time.now.to_f)
+      assert_equal job_args[0..-2], ["arg1", :arg2]
+    end
+
   end
 
   describe "cron test" do


### PR DESCRIPTION
new mandatory job property to have the original execution date of the job as last argument of the perform method.

Useful if you need to use the theoretical execution time into your worker but is delayed due to insufficient threads number, or retries.