### PR TITLE
Allow job to be described using a human readable sentence

### DIFF
--- a/lib/sidekiq/cron/locales/en.yml
+++ b/lib/sidekiq/cron/locales/en.yml
@@ -17,3 +17,4 @@ en:
   disabled: disabled
   enabled: enabled
   NoHistoryWereFound: No history were found
+  Description: Description

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -40,6 +40,10 @@
     <td><%= @job.name %></td>
   </tr>
   <tr>
+    <th><%= t 'Description' %></th>
+    <td><%= @job.description %></td>
+  </tr>
+  <tr>
     <th><%= t 'Message' %></th>
     <td><pre><%= @job.pretty_message %></pre></td>
   </tr>

--- a/lib/sidekiq/cron/views/cron_show.slim
+++ b/lib/sidekiq/cron/views/cron_show.slim
@@ -29,6 +29,9 @@ table.table.table-bordered.table-striped
       th= t 'Name'
       td= @job.name
     tr
+      th= t 'Description'
+      td= @job.description
+    tr
       th= t 'Message'
       td
         pre= @job.pretty_message


### PR DESCRIPTION
I am replacing a few rake tasks using sidekiq cron and I found useful to be able to have a short description for them.

<img width="722" alt="screen shot 2018-09-07 at 1 04 22 pm" src="https://user-images.githubusercontent.com/60936/45232860-f7fe1180-b29e-11e8-8528-cabf5c89aa0a.png">

This adds a row to the detail view (I think will be released in the upcoming version soon?)

When no description is set, it render just an empty row.