### PR TITLE
Update README in respect of rufus-scheduler bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Upgrade from <0.6x to 1.0.x
 
 Be aware that there was change from rufus-scheduler to fugit. Also there was change in handling Timezones, so after upgrade check that your jobs are enqueued in correct times. Best thing to do is correctly set timezone in cron notations.
 
+The issue is versions `3.5` of rufus-scheduler are not compactible with versions under `1.0` of this gem, be aware that `Sidekiq::Cron::Job.create` will return false and not schedule your job/worker.
+
 Requirements
 -----------------
 


### PR DESCRIPTION
I encountered a problem in production that persisted for quite time until I found out that sidekiq-cron versions lower than `1.0` have a problem with rufus-scheduler version `3.5`.

Maybe updating the README with that note will be useful for other people. :)