### PR TITLE
fix: undefined method .present? for Sidekiq::Cron::Job

### DIFF
--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -25,15 +25,14 @@ module Sidekiq
           view_path = File.join(File.expand_path("..", __FILE__), "views")
 
           @job = Sidekiq::Cron::Job.find(route_params[:name])
-          if @job
-            #if Slim renderer exists and sidekiq has layout.slim in views
-            if defined?(Slim) && File.exists?(File.join(settings.views,"layout.slim"))
-              render(:slim, File.read(File.join(view_path, "cron_show.slim")))
-            else
-              render(:erb, File.read(File.join(view_path, "cron_show.erb")))
-            end
+
+          redirect "#{root_path}cron" unless @job
+
+          #if Slim renderer exists and sidekiq has layout.slim in views
+          if defined?(Slim) && File.exists?(File.join(settings.views,"layout.slim"))
+            render(:slim, File.read(File.join(view_path, "cron_show.slim")))
           else
-            redirect "#{root_path}cron"
+            render(:erb, File.read(File.join(view_path, "cron_show.erb")))
           end
         end
 

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -76,12 +76,14 @@ describe 'Cron web' do
           Sidekiq.load_json(history.last)['jid']
         end
 
+      assert_equal 200, last_response.status
       assert last_response.body.include?(jid)
     end
 
     it 'redirects to cron path when name not found' do
       get '/cron/some-fake-name'
 
+      assert_equal 302, last_response.status
       assert_match %r{\/cron\z}, last_response['Location']
     end
 


### PR DESCRIPTION
### Description

Since `sidekiq-cron` 1.1.0 the ui is broken for the endpoint:

```rb
get '/cron/:name'
```

The breaking change introduce was not visible in the tests since the method `.present?` was added by a development dependency:

```
[9] pry(#<Sidekiq::WebAction>)> @job.method(:present?).source_location
=> ["/Users/mberlanda/Misc/sidekiq-cron/vendor/ruby/2.5.0/gems/tins-1.20.2/lib/tins/xt/blank.rb", 8]
```

I assume also that the most of the users have mounted the routing on rails application where `.present?` is defined by ActiveSupport (see [Rails doc](https://guides.rubyonrails.org/active_support_core_extensions.html#blank-questionmark-and-present-questionmark)).

I was running the UI on a rack standalone app and I got the following error message:

![image](https://user-images.githubusercontent.com/16099063/55553632-fbe0fd80-56e0-11e9-8f81-caf46e9e5a1b.png)

After this fix, the behaviour came back as expected:

![image](https://user-images.githubusercontent.com/16099063/55553652-0f8c6400-56e1-11e9-925d-ef5bdd4a5b4d.png)

### Changes

Stop calling `.present?` on a `Sidekiq::Cron::Job` instance since it won't be defined for Rack and Sinatra apps not including ActiveSupport