### PR TITLE
Check hash is not truthy on load_from_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ second_job:
 schedule_file = "config/schedule.yml"
 
 if File.exist?(schedule_file) && Sidekiq.server?
-  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+  hash = YAML.load_file(schedule_file)
+  Sidekiq::Cron::Job.load_from_hash(hash) if hash
 end
 ```
 
@@ -281,7 +282,8 @@ Sidekiq.configure_server do |config|
   schedule_file = "config/schedule.yml"
 
   if File.exist?(schedule_file)
-    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+    hash = YAML.load_file(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash(hash) if hash
   end
 end
 ```


### PR DESCRIPTION
Hi,

When the file is blank for example with:

`YAML.load_file("/dev/null") # => false`

As a result `load_from_hash` fail with an error like:

`NoMethodError: undefined method inject for false:FalseClass`

And sidekiq server does not start

Cheers