### PR TITLE
Add javascript confirmation to enqueue buttons

### DIFF
--- a/lib/sidekiq/cron/locales/en.yml
+++ b/lib/sidekiq/cron/locales/en.yml
@@ -8,6 +8,8 @@ en:
   EnqueueAll: Enqueue All
   DeleteAll: Delete All
   'Cron string': Cron
+  AreYouSureEnqueueCronJobs: Are you sure you want to enqueue ALL cron jobs?
+  AreYouSureEnqueueCronJob: Are you sure you want to enqueue the %{job} cron job?
   AreYouSureDeleteCronJobs: Are you sure you want to delete ALL cron jobs?
   AreYouSureDeleteCronJob: Are you sure you want to delete the %{job} cron job?
   NoCronJobsWereFound: No cron jobs were found

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -1,12 +1,12 @@
 <header class='row'>
   <div class='col-sm-5 pull-left'>
-    <h3><%=t 'CronJobs' %></h3>
+    <h3><%= t('CronJobs') %></h3>
   </div>
   <div class='col-sm-7 pull-right' style="margin-top: 20px; margin-bottom: 10px;">
     <% if @cron_jobs.size > 0 %>
       <form action="<%= root_path %>cron/__all__/delete" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
-        <input class="btn btn-small btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>">
+        <input class="btn btn-small btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
       </form>
       <form action="<%= root_path %>cron/__all__/disable" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
@@ -18,7 +18,7 @@
       </form>
       <form action="<%= root_path %>cron/__all__/enque" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
-        <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnqueueAll') %>" />
+        <input class="btn btn-small" type="submit" name="enque" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
       </form>
     <% end %>
   </div>
@@ -61,7 +61,7 @@
             <% if job.status == 'enabled' %>
               <form action="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
-                <input class='btn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>"/>
+                <input class='btn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
               </form>
               <form action="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>/disable" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>

--- a/lib/sidekiq/cron/views/cron.slim
+++ b/lib/sidekiq/cron/views/cron.slim
@@ -15,7 +15,7 @@ header.row
         input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnableAll')}"
       form.pull-right action="#{root_path}cron/__all__/enque" method="post"
         = csrf_tag if respond_to?(:csrf_tag)
-        input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueAll')}"
+        input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueAll')}" data-confirm="#{t('AreYouSureEnqueueCronJobs')}"
 
 - if @cron_jobs.size > 0
 
@@ -59,7 +59,7 @@ header.row
           -else
             form action="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}/enque" method="post"
               = csrf_tag if respond_to?(:csrf_tag)
-              input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueNow')}"
+              input.btn.btn-small.pull-left type="submit" name="enque" value="#{t('EnqueueNow')}" data-confirm="#{t('AreYouSureEnqueueCronJob', :job => job.name)}"
             form action="#{root_path}cron/#{CGI.escape(job.name).gsub('+', '%20')}/enable" method="post"
               = csrf_tag if respond_to?(:csrf_tag)
               input.btn.btn-small.pull-left type="submit" name="enable" value="#{t('Enable')}"

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -9,7 +9,7 @@
     <% cron_job_path = "#{root_path}cron/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
     <form action="<%= cron_job_path %>/enque?redirect=<%= cron_job_path %>" class="pull-right" method="post">
       <%= csrf_tag if respond_to?(:csrf_tag) %>
-      <input class="btn btn-small pull-left" name="enque" type="submit" value="<%= t('EnqueueNow') %>" />
+      <input class="btn btn-small pull-left" name="enque" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
     </form>
     <% if @job.status == 'enabled' %>
       <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>" class="pull-right" method="post">

--- a/lib/sidekiq/cron/views/cron_show.slim
+++ b/lib/sidekiq/cron/views/cron_show.slim
@@ -18,7 +18,7 @@ header.row
         input.btn.btn-small.pull-left name="enable" type="submit" value="#{t('Enable')}"
       form.pull-right action="#{cron_job_path}/delete" method="post"
         = csrf_tag if respond_to?(:csrf_tag)
-        input.btn.btn-danger.btn-small data-confirm="#{t('AreYouSureDeleteCronJob' job =@job.name)}" name="delete" type="submit" value="#{t('Delete')}" /
+        input.btn.btn-danger.btn-small data-confirm="#{t('AreYouSureDeleteCronJob', :job => @job.name)}" name="delete" type="submit" value="#{t('Delete')}" /
 
 table.table.table-bordered.table-striped
   tbody

--- a/lib/sidekiq/cron/views/cron_show.slim
+++ b/lib/sidekiq/cron/views/cron_show.slim
@@ -7,7 +7,7 @@ header.row
     - cron_job_path = "#{root_path}cron/#{CGI.escape(@job.name).gsub('+', '%20')}"
     form.pull-right action="#{cron_job_path}/enque?redirect=#{cron_job_path}" method="post"
       = csrf_tag if respond_to?(:csrf_tag)
-      input.btn.btn-small.pull-left name="enque" type="submit" value="#{t('EnqueueNow')}"
+      input.btn.btn-small.pull-left data-confirm="#{t('AreYouSureEnqueueCronJob', :job => @job.name)}" name="enque" type="submit" value="#{t('EnqueueNow')}"
     - if @job.status == 'enabled'
       form.pull-right action="#{cron_job_path}/disable?redirect=#{cron_job_path}" method="post"
         = csrf_tag if respond_to?(:csrf_tag)

--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -25,7 +25,7 @@ module Sidekiq
           view_path = File.join(File.expand_path("..", __FILE__), "views")
 
           @job = Sidekiq::Cron::Job.find(route_params[:name])
-          if @job.present?
+          if @job
             #if Slim renderer exists and sidekiq has layout.slim in views
             if defined?(Slim) && File.exists?(File.join(settings.views,"layout.slim"))
               render(:slim, File.read(File.join(view_path, "cron_show.slim")))


### PR DESCRIPTION
I accidentally clicked on an `enqueue` button and kicked off a worker that was not supposed to be run. This adds javascript confirmation dialogs to those buttons so this accident is less likely to happen.