### PR TITLE
[RFC] Add ability to symbolize keys so it can be used with keyword args

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -279,6 +279,7 @@ module Sidekiq
         end
 
         #get right arguments for job
+        @symbolize_args = args["symbolize_args"] == true || ("#{args["symbolize_args"]}" =~ (/^(true|t|yes|y|1)$/i)) == 0 || false
         @args = args["args"].nil? ? [] : parse_args( args["args"] )
         @args += [Time.now.to_f] if args["date_as_argument"]
 
@@ -401,6 +402,7 @@ module Sidekiq
           queue_name_prefix: @active_job_queue_name_prefix,
           queue_name_delimiter: @active_job_queue_name_delimiter,
           last_enqueue_time: @last_enqueue_time,
+          symbolize_args: @symbolize_args,
         }
       end
 
@@ -571,16 +573,31 @@ module Sidekiq
         case args
         when String
           begin
-            Sidekiq.load_json(args)
+            parsed_args = Sidekiq.load_json(args)
+            symbolize_args? ? symbolize_args(parsed_args) : parsed_args
           rescue JSON::ParserError
             [*args]   # cast to string array
           end
         when Hash
-          [args]      # just put hash into array
+          symbolize_args? ? [args.symbolize_keys] : [args]
         when Array
-          args        # do nothing, already array
+          symbolize_args? ? symbolize_args : parsed_args
         else
           [*args]     # cast to string array
+        end
+      end
+
+      def symbolize_args?
+        @symbolize_args
+      end
+
+      def symbolize_args(args = @args)
+        args.map do |arg|
+          if arg.respond_to?(:symbolize_keys)
+            arg.symbolize_keys
+          else
+            arg
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #274

I am not sure if this is the way the maintainer wants to move on with the gem, but one approach would be adding a new argument for retro compatibility purposes and convert the argument if the argument is ready.

Essentially, I created this argument called `symbolize_args` and in case it was set, we'd symbolize the hash keys so before we actually send them to ActiveJob.

Can I get some comments here if this is the way to move forward? I'll implement tests once confirmed.