### PR TITLE
validate jobs in Job.find

### DIFF
--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -4,5 +4,6 @@ require "sidekiq/cron/launcher"
 
 module Sidekiq
   module Cron
+    Redis.respond_to?(:exists_returns_integer) && Redis.exists_returns_integer =  false
   end
 end

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -233,7 +233,7 @@ module Sidekiq
             output = Job.new conn.hgetall( redis_key(name) )
           end
         end
-        output if output.valid?
+        output if output&.valid?
       end
 
       # create new instance of cron job

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -233,7 +233,7 @@ module Sidekiq
             output = Job.new conn.hgetall( redis_key(name) )
           end
         end
-        output if output&.valid?
+        output if output && output.valid?
       end
 
       # create new instance of cron job

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -233,7 +233,7 @@ module Sidekiq
             output = Job.new conn.hgetall( redis_key(name) )
           end
         end
-        output
+        output if output.valid?
       end
 
       # create new instance of cron job


### PR DESCRIPTION
In the case of two or more Sidekiq workers the job hash in Redis can be
left in a partly deleted state after one worker deletes the job and
another worker sets the last_enqueue_time value. If this happens
before this commit then calls to Job.find will return an invalid job
that doesn't have a  name (or any properties but last_enqueue_time)
and can't be destroyed. After this commit nil is returned if the Job is
not valid.