### PR TITLE
Document natural language cron expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ second_job:
   queue: hard_worker_long
   args:
     hard: "stuff"
+
+third_job:
+  cron: "every 30 minutes" # Natural language is accepted and parsed by Fugit
+  class: "HardWorker"
+  queue: hard_worker
+
 ```
 
 ```ruby


### PR DESCRIPTION
Fugit understands some kind of [natural language](https://github.com/floraison/fugit#fugitnat).

I have tried it in sidekiq-cron and it works, which is nice when listing scheduled jobs in YML, similarly to the [whenever](https://github.com/javan/whenever) gem.

This PR documents this use case.