### PR TITLE
Use Redis#exists? instead of Redis#exists

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -461,7 +461,7 @@ module Sidekiq
 
           #add information about last time! - don't enque right after scheduler poller starts!
           time = Time.now.utc
-          conn.zadd(job_enqueued_key, time.to_f.to_s, formated_last_time(time).to_s) unless conn.exists(job_enqueued_key)
+          conn.zadd(job_enqueued_key, time.to_f.to_s, formated_last_time(time).to_s) unless conn.exists?(job_enqueued_key)
         end
         logger.info { "Cron Jobs - add job with name: #{@name}" }
       end
@@ -540,7 +540,7 @@ module Sidekiq
       def self.exists? name
         out = false
         Sidekiq.redis do |conn|
-          out = conn.exists redis_key name
+          out = conn.exists? redis_key name
         end
         out
       end


### PR DESCRIPTION
Follow the advice warned by recent versions of redis-rb:

`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (~/.rvm/gems/ruby-2.6.3/gems/sidekiq-cron-1.2.0/lib/sidekiq/cron/job.rb:464:in `block in save')