### PR TITLE
Get polling interval from `average_scheduled_poll_interval`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@ v 1.3.0 (in progress)
 -------
 
 - add confirmation dialog when enquing jobs from UI
+- Start to support Sidekiq `average_scheduled_poll_interval` option (replaced `poll_interval`)
 
 v 1.2.0
 -------

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ Sidekiq-Cron adds itself into this start procedure and starts another thread wit
 
 Sidekiq-Cron is checking jobs to be enqueued every 30s by default, you can change it by setting:
 ```
+# For Sidekiq >= 3.4
+Sidekiq.options[:average_scheduled_poll_interval] = 10
+
+# For older versions of Sidekiq
 Sidekiq.options[:poll_interval] = 10
 ```
 

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -34,7 +34,7 @@ module Sidekiq
       end
 
       def poll_interval_average
-         Sidekiq.options[:poll_interval] || POLL_INTERVAL
+         Sidekiq.options[:average_scheduled_poll_interval] || Sidekiq.options[:poll_interval] || POLL_INTERVAL
       end
     end
   end


### PR DESCRIPTION
Sidekiq renamed the `poll_interval` setting in [3.4.0](https://github.com/mperham/sidekiq/blob/285d6541a51d2d06f288036e96244f98f012c6ca/Changes.md#340) to be `average_scheduled_poll_interval`. 
This change should work for both newer versions of Sidekiq, and still be backwards compatible for older versions.

Resolves #254 