### PR TITLE
feat: enable/disable via SIDEKIQ_CRON_ENABLE env-var

### DIFF
--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -39,7 +39,7 @@ module Sidekiq
   end
 end
 
-if ENV["SIDEKIQ_CRON_ENABLE"] != "0"
+if ENV['SIDEKIQ_CRON_ENABLE'] != '0'
   Sidekiq.configure_server do
     # require  Sidekiq original launcher
     require 'sidekiq/launcher'

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -39,9 +39,11 @@ module Sidekiq
   end
 end
 
-Sidekiq.configure_server do
-  # require  Sidekiq original launcher
-  require 'sidekiq/launcher'
+if ENV["SIDEKIQ_CRON_ENABLE"] != "0"
+  Sidekiq.configure_server do
+    # require  Sidekiq original launcher
+    require 'sidekiq/launcher'
 
-  ::Sidekiq::Launcher.prepend(Sidekiq::Cron::Launcher)
+    ::Sidekiq::Launcher.prepend(Sidekiq::Cron::Launcher)
+  end
 end


### PR DESCRIPTION
sidekiq-cron by design runs on every worker/server we have, but
if that is not needed, it would be nice to reduce overhead by
individually controlling which servers run it and which do not.
This commit introduces a trigger to disable the sidekiq-cron
launcher using an environment variable specified in sidekiq's
systemd unit file. Eg.

```
[Unit]
(as normal)

[Service]
Type=...
WorkingDirectory=...
Environment=SIDEKIQ_CRON_ENABLE=0
(other options and env-vars)

[Install]
WantedBy=sidekiq.service
```

Setting SIDEKIQ_CRON_ENABLE=0 will disable sidekiq-cron
for that particular sidekiq instance. The intention is that certain
job-servers can have SIDEKIQ_CRON_ENABLE=0 in all of their
instance files; other servers that still run sidekiq-cron can either
have set SIDEKIQ_CRON_ENABLE=1, or leave it unset, which
will not disable. As per the initial req:

https://app.asana.com/0/1199694928672053/1200088851159839/f

sidekiq-cron is only disabled if SIDEKIQ_CRON_ENABLE=0. If
it is 1, unset, or any other value than 0, sidekiq-cron launches as
normal.