### PR TITLE
Make log message more obvious

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -466,7 +466,7 @@ module Sidekiq
           time = Time.now.utc
           conn.zadd(job_enqueued_key, time.to_f.to_s, formated_last_time(time).to_s) unless conn.public_send(REDIS_EXISTS_METHOD, job_enqueued_key)
         end
-        logger.info { "Cron Jobs - add job with name: #{@name}" }
+        logger.info { "Cron Jobs - added job with name: #{@name}" }
       end
 
       def save_last_enqueue_time


### PR DESCRIPTION
`Cron Jobs - add job with name:` seemed like a warning that some action needs to be taken ¯\\_(ツ)\_/¯