### PR TITLE
Fix redis-rb v4.6.0 pipelining depreciation

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -206,9 +206,9 @@ module Sidekiq
         job_hashes = nil
         Sidekiq.redis do |conn|
           set_members = conn.smembers(jobs_key)
-          job_hashes = conn.pipelined do
+          job_hashes = conn.pipelined do |pipeline|
             set_members.each do |key|
-              conn.hgetall(key)
+              pipeline.hgetall(key)
             end
           end
         end


### PR DESCRIPTION
Hi, this is a small fix for the depreciation alert that appeared with version 4.6.0 of redis-rb which can pollute the logs quite a bit.