### PR TITLE
fix pipelining redis instance is deprecated

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -206,9 +206,9 @@ module Sidekiq
         job_hashes = nil
         Sidekiq.redis do |conn|
           set_members = conn.smembers(jobs_key)
-          job_hashes = conn.pipelined do
+          job_hashes = conn.pipelined do |pipeline|
             set_members.each do |key|
-              conn.hgetall(key)
+              pipeline.hgetall(key)
             end
           end
         end


### PR DESCRIPTION
Fix Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0

```ruby
redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end
```