### PR TITLE
Allow natural language definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Enable to use latest fugit to parse cron notation allowing use of natural language (ie `"every 30 minutes"`)
+
 ## 1.6.0
 
 - Adds support for auto-loading the config/schedule.yml file (https://github.com/ondrejbartas/sidekiq-cron/pull/337)
@@ -30,7 +34,6 @@ All notable changes to this project will be documented in this file.
 
 - Add confirmation dialog when enquing jobs from UI
 - Start to support Sidekiq `average_scheduled_poll_interval` option (replaced `poll_interval`)
-- Enable to use latest fugit to parse cron notation alowing use of natural language (ie `"every 30 minutes"`)
 - Fix deprecation warning for Redis 4.6.x
 - Fix different response from Redis#exists in different Redis versions
 - All PRs:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ like this `'0 22 * * 1-5 America/Chicago'`.
 
 #### Natural-language formats
 
-Since sidekiq-cron `v1.3.0`, you can use the natural-language formats supported by Fugit, such as:
+Since sidekiq-cron `v1.7.0`, you can use the natural-language formats supported by Fugit, such as:
 
 ```rb
 "every day at five" # ==> '0 5 * * *'

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ If using Rails, this is evaluated against the timezone configured in Rails, othe
 If you want to have your jobs enqueued based on a different time zone you can specify a timezone in the cronline,
 like this `'0 22 * * 1-5 America/Chicago'`.
 
+#### Natural-language formats
+
+Since `v1.3.0`, you can use the natural-language formats supported by Fugit, such as:
+
+```rb
+"every day at five" # ==> '0 5 * * *'
+"every 3 hours"     # ==> '0 */3 * * *'
+```
+
+See [the relevant part of Fugit documentation](https://github.com/floraison/fugit#fugitnat) for details.
+
 #### Second-precision (sub-minute) cronlines
 
 In addition to the standard 5-parameter cronline format, sidekiq-cron supports scheduling jobs with second-precision using a modified 6-parameter cronline format:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ like this `'0 22 * * 1-5 America/Chicago'`.
 
 #### Natural-language formats
 
-Since `v1.3.0`, you can use the natural-language formats supported by Fugit, such as:
+Since sidekiq-cron `v1.3.0`, you can use the natural-language formats supported by Fugit, such as:
 
 ```rb
 "every day at five" # ==> '0 5 * * *'

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -417,7 +417,7 @@ module Sidekiq
           errors << "'cron' must be set"
         else
           begin
-            @parsed_cron = Fugit.do_parse_cron(@cron)
+            @parsed_cron = Fugit.do_parse(@cron)
           rescue => e
             errors << "'cron' -> #{@cron.inspect} -> #{e.class}: #{e.message}"
           end
@@ -557,7 +557,7 @@ module Sidekiq
       private
 
       def parsed_cron
-        @parsed_cron ||= Fugit.parse_cron(@cron)
+        @parsed_cron ||= Fugit.parse(@cron)
       end
 
       def not_enqueued_after?(time)

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -130,6 +130,22 @@ describe "Cron Job" do
     end
   end
 
+  describe 'cron formats' do
+    before do
+      @args = {
+        name: "Test",
+        klass: "CronTestClass"
+      }
+    end
+
+    it 'should support natural language format' do
+      @args[:cron] = "every 3 hours"
+      @job = Sidekiq::Cron::Job.new(@args)
+      assert @job.valid?
+      assert_equal Fugit::Cron.new("0 */3 * * *"), @job.send(:parsed_cron)
+    end
+  end
+
   describe 'parse_enqueue_time' do
     before do
       @args = {


### PR DESCRIPTION
I'm not sure why fugit was locked on 1.1.

Upgrading the dependency allows to use recent features such as natural language definitions (ie `"every 30 minutes"`).

This will fix #229

Related to #293