### PR TITLE
redis: invocation of deprecated functionality removed

### DIFF
--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -4,6 +4,5 @@ require "sidekiq/cron/launcher"
 
 module Sidekiq
   module Cron
-    Redis.respond_to?(:exists_returns_integer) && Redis.exists_returns_integer =  false
   end
 end


### PR DESCRIPTION
There is a deprecation warning still in place after https://github.com/ondrejbartas/sidekiq-cron/pull/288 was merged.
This PR is intended to remove the warning as there is no more sense to set `exists_returns_integer` as PR above introduced proper method invocation based on redis version. 