### PR TITLE
Avoid setting global Redis option (fix warning)

### DIFF
--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -4,6 +4,5 @@ require "sidekiq/cron/launcher"
 
 module Sidekiq
   module Cron
-    Redis.respond_to?(:exists_returns_integer) && Redis.exists_returns_integer =  false
   end
 end


### PR DESCRIPTION
After upgrading to sidekiq-cron v1.3, I've started getting this warning from the `Redis` gem (v4.6.0):
```
`Redis#exists(key)` will return an Integer by default in redis-rb 4.3. The option to explicitly disable this behaviour via `Redis.exists_returns_integer` will be removed in 5.0. You should use `exists?` instead.
```

After some investigation I've realized that sidekiq-cron was _modifying a global option_ on the `Redis` gem, and that this started on the seemingly unrelated PR https://github.com/ondrejbartas/sidekiq-cron/pull/287

Since there were no comments about this on the PR description, and that #288 already made sidekiq-cron compliant with the `exists` change (making the config change irrelevant for sidekiq-cron), I assume this was changed by mistake.