### PR TITLE
Optimize gem size

### DIFF
--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -17,9 +17,6 @@ Gem::Specification.new do |s|
   ]
   s.files = Dir.glob('lib/**/*') + Dir.glob('test/**/*') + [
     "Changes.md",
-    "Dockerfile",
-    "docker-compose.yml",
-    "examples/web-cron-ui.png",
     "Gemfile",
     "LICENSE.txt",
     "Rakefile",


### PR DESCRIPTION
I'd say there is no need to bundle Docker files or screenshots when building the gem. This will reduce the gem size a lot (current gem size: 178 KB, image size: 150K).