### PR TITLE
release gem using Bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
+require 'bundler/gem_tasks'
 require 'rake/testtask'
+
 task :default => :test
 
 Rake::TestTask.new(:test) do |t|


### PR DESCRIPTION
By requiring these Bundler provided tasks, we have now access to cool 😎  tools to work more easily (release, build locally, ...) with the gem:

```
$ rake -T
rake build             # Build sidekiq-cron-1.3.0.gem into the pkg directory
rake build:checksum    # Generate SHA512 checksum if sidekiq-cron-1.3.0.gem into the checksums directory
rake clean             # Remove any temporary products
rake clobber           # Remove any generated files
rake install           # Build and install sidekiq-cron-1.3.0.gem into system gems
rake install:local     # Build and install sidekiq-cron-1.3.0.gem into system gems without network access
rake release[remote]   # Create tag v1.3.0 and build and push sidekiq-cron-1.3.0.gem to rubygems.org
rake test              # Run tests
rake test:integration  # Run tests for integration
rake test:unit         # Run tests for unit
```

The most interesting for me (I've been using it to release all my gems for years) is the **release** command. 

To release a new version:
- Edit version number in `lib/sidekiq/cron/version.rb`
- `git commit` that change ☝🏼 
- Run: `rake release`

ℹ️ https://bundler.io/guides/creating_gem.html#releasing-the-gem

There are another gems/plugins to make even more automatic, but IMO this is "just enough" ™️ and it relies only in Bundler (which anyway is now bundled inside Ruby), so no need for more (dev-)dependencies.