### PR TITLE
Fix/sidekiq 6.5 breaking changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.6
 MAINTAINER Joao Serra <joaopfserra@gmail.com>
 
 RUN apt-get update && \

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -1,15 +1,10 @@
 require 'fugit'
 require 'sidekiq'
-require 'sidekiq/util'
 require 'sidekiq/cron/support'
 
 module Sidekiq
   module Cron
-
     class Job
-      include Util
-      extend Util
-
       #how long we would like to store informations about previous enqueues
       REMEMBER_THRESHOLD = 24 * 60 * 60
       LAST_ENQUEUE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S %z'
@@ -76,7 +71,7 @@ module Sidekiq
 
         save_last_enqueue_time
         add_jid_history jid
-        logger.debug { "enqueued #{@name}: #{@message}" }
+        Sidekiq.logger.debug { "enqueued #{@name}: #{@message}" }
       end
 
       def is_active_job?
@@ -468,7 +463,7 @@ module Sidekiq
           time = Time.now.utc
           conn.zadd(job_enqueued_key, time.to_f.to_s, formated_last_time(time).to_s) unless conn.public_send(REDIS_EXISTS_METHOD, job_enqueued_key)
         end
-        logger.info { "Cron Jobs - added job with name: #{@name}" }
+        Sidekiq.logger.info { "Cron Jobs - added job with name: #{@name}" }
       end
 
       def save_last_enqueue_time
@@ -509,7 +504,7 @@ module Sidekiq
           #delete main job
           conn.del redis_key
         end
-        logger.info { "Cron Jobs - deleted job with name: #{@name}" }
+        Sidekiq.logger.info { "Cron Jobs - deleted job with name: #{@name}" }
       end
 
       # remove all job from cron
@@ -517,7 +512,7 @@ module Sidekiq
         all.each do |job|
           job.destroy
         end
-        logger.info { "Cron Jobs - deleted all jobs" }
+        Sidekiq.logger.info { "Cron Jobs - deleted all jobs" }
       end
 
       # remove "removed jobs" between current jobs and new jobs

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -1,5 +1,4 @@
 require 'sidekiq'
-require 'sidekiq/util'
 require 'sidekiq/cron'
 require 'sidekiq/scheduled'
 
@@ -9,6 +8,19 @@ module Sidekiq
 
     # The Poller checks Redis every N seconds for sheduled cron jobs
     class Poller < Sidekiq::Scheduled::Poller
+      def initialize
+        Sidekiq.configure_server do |config|
+          config[:poll_interval_average] = config[:average_scheduled_poll_interval] || POLL_INTERVAL
+        end
+
+        if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("6.5.0")
+          # Sidekiq Poller init requires a config argument
+          super(Sidekiq)
+        else
+          super
+        end
+      end
+
       def enqueue
         time = Time.now.utc
         Sidekiq::Cron::Job.all.each do |job|
@@ -31,10 +43,6 @@ module Sidekiq
         Sidekiq.logger.error "CRON JOB: #{ex.message}"
         Sidekiq.logger.error "CRON JOB: #{ex.backtrace.first}"
         handle_exception(ex) if respond_to?(:handle_exception)
-      end
-
-      def poll_interval_average
-         Sidekiq.options[:average_scheduled_poll_interval] || POLL_INTERVAL
       end
     end
   end

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name = "sidekiq-cron"
   s.version = Sidekiq::Cron::VERSION
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.6"
   s.require_paths = ["lib"]
   s.authors = ["Ondrej Bartas"]
   s.description = "Enables to set jobs to be run in specified time (using CRON notation)"
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     "README.md",
     "sidekiq-cron.gemspec",
   ]
- 
+
   s.homepage = "https://github.com/ondrejbartas/sidekiq-cron"
   s.licenses = ["MIT"]
   s.summary = "Sidekiq-Cron helps to add repeated scheduled jobs"
@@ -31,11 +31,11 @@ Gem::Specification.new do |s|
   s.add_dependency("fugit", "~> 1")
   s.add_dependency("sidekiq", ">= 4.2.1")
 
-  s.add_development_dependency("minitest")
-  s.add_development_dependency("mocha")
-  s.add_development_dependency("redis-namespace", ">= 1.5.2")
-  s.add_development_dependency("rack", "~> 2.0")
-  s.add_development_dependency("rack-test", "~> 1.0")
+  s.add_development_dependency("minitest", "~> 5.15")
+  s.add_development_dependency("mocha", "~> 1.14")
+  s.add_development_dependency("redis-namespace", "~> 1.8")
+  s.add_development_dependency("rack", "~> 2.2")
+  s.add_development_dependency("rack-test", "~> 1.1")
   s.add_development_dependency("rake", "~> 13.0")
-  s.add_development_dependency("simplecov")
+  s.add_development_dependency("simplecov", "~> 0.21")
 end


### PR DESCRIPTION
This PR is focused to adapt the project to support the changes coming from the Sidekiq 6.5.

- The sidekiq/util file is not available anymore. And we don't really need it. I just changed to use the logger from the Sidekiq module;
- Update the Ruby version references to 2.6 (dockerfile) and some dev dependencies;
- The Poller class requires an argument when Sidekiq version is >= 6.5. I fixed it passing the Sidekiq options. Seems like the right workaround as I could see in the sidekiq repo.

Closes #330