### PR TITLE
Adds support for auto-loading the `config/schedule.yml` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,21 +233,13 @@ There are multiple ways to load the jobs from a YAML file
 2. When you want to load jobs from a different filename, mention the filename in sidekiq configuration,
 i.e. `cron_schedule_file: "config/users_schedule.yml"`
 3. Load the file manually as follows
+
 ```ruby
 # config/initializers/sidekiq.rb
-schedule_file = "config/users_schedule.yml"
 
-if File.exist?(schedule_file) && Sidekiq.server?
-  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
-end
-```
-
-From version 3.x it is better not to use separate initializer of schedule instead add `config.on(:startup)` to your Sidekiq configuration:
-
-```ruby
 Sidekiq.configure_server do |config|
   config.on(:startup) do
-    schedule_file = "config/schedule.yml"
+    schedule_file = "config/users_schedule.yml"
 
     if File.exist?(schedule_file)
       Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)

--- a/README.md
+++ b/README.md
@@ -322,30 +322,6 @@ With this, you will get:
 
 ![Web UI](examples/web-cron-ui.png)
 
-### Forking Processes or problem with `NotImplementedError`
-
-If you're using a forking web server like Unicorn you may run into an issue where the Redis connection is used
-before the process forks, causing the following exception to occur:
-
-```
-Redis::InheritedError: Tried to use a connection from a child process without reconnecting. You need to reconnect to Redis after forking.
-```
-
-To avoid this, wrap your job creation in the call to `Sidekiq.configure_server`:
-
-```ruby
-Sidekiq.configure_server do |config|
-  config.on(:startup) do
-    schedule_file = "config/schedule.yml"
-
-    if File.exist?(schedule_file)
-      Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
-    end
-  end
-end
-```
-
-**NOTE** This API is only available in Sidekiq 3.x.
 
 ## Under the hood
 

--- a/README.md
+++ b/README.md
@@ -227,9 +227,15 @@ second_job:
     hard: "stuff"
 ```
 
+There are multiple ways to load the jobs from a YAML file
+
+1. The gem will automatically load the jobs mentioned in `config/schedule.yml` file.
+2. When you want to load jobs from a different filename, mention the filename in sidekiq configuration,
+i.e. `cron_schedule_file: "config/users_schedule.yml"`
+3. Load the file manually as follows
 ```ruby
 # config/initializers/sidekiq.rb
-schedule_file = "config/schedule.yml"
+schedule_file = "config/users_schedule.yml"
 
 if File.exist?(schedule_file) && Sidekiq.server?
   Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -1,6 +1,7 @@
 require "sidekiq/cron/job"
 require "sidekiq/cron/poller"
 require "sidekiq/cron/launcher"
+require "sidekiq/cron/schedule_loader"
 
 module Sidekiq
   module Cron

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -7,9 +7,7 @@ if Sidekiq.server?
 
     if File.exist?(schedule_file)
       config.on(:startup) do
-        if File.exist?(schedule_file)
-          Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
-        end
+        Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
       end
     end
   end

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -1,0 +1,16 @@
+require "sidekiq"
+require "sidekiq/cron/job"
+
+if Sidekiq.server?
+  Sidekiq.configure_server do |config|
+    schedule_file = config.options[:cron_schedule_file] || "config/schedule.yml"
+
+    if File.exist?(schedule_file)
+      config.on(:startup) do
+        if File.exist?(schedule_file)
+          Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+        end
+      end
+    end
+  end
+end

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -1030,6 +1030,16 @@ describe "Cron Job" do
         assert_equal Sidekiq::Cron::Job.all.size, 2, "Should have 2 jobs after load"
       end
 
+      it "duplicate jobs are not loaded" do
+        out = Sidekiq::Cron::Job.load_from_hash @jobs_hash
+        assert_equal out.size, 0, "should have no errors"
+        assert_equal Sidekiq::Cron::Job.all.size, 2, "Should have 2 jobs after load"
+
+        out_2 = Sidekiq::Cron::Job.load_from_hash @jobs_hash
+        assert_equal out_2.size, 0, "should have no errors"
+        assert_equal Sidekiq::Cron::Job.all.size, 2, "Should have 2 jobs after loading again"
+      end
+
       it "return errors on loaded jobs" do
         assert_equal Sidekiq::Cron::Job.all.size, 0, "Should have 0 jobs before load"
         #set something bag to hash


### PR DESCRIPTION
fixes #250

With this change, we do not need to explicitly keep an initializer to load the `config/schedule.yml` file. If someone wants to use a different name, that's possible by putting the following configuration in sidekiq options.

```yml
default: &default
  :concurrency: 5

production:
  <<: *default
  cron_schedule_file: "config/schedule_prod.yml"

queues:
  - default
```

For some reason, if someone decides to go the initializer way, that'll work too. Have verified that the jobs don't enqueue again.

As an added benefit, this gives flexibility in having different schedules for different environments. 
_(Not sure why that will be needed but, it's there😃)_

----

### Documentation Screenshot:

![image](https://user-images.githubusercontent.com/9862943/173201226-500e1377-e169-4066-b63f-2470f737a30d.png)