### PR TITLE
Fix Sidekiq.options deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For example: `"*/30 * * * * *"` would schedule a job to run every 30 seconds.
 Note that if you plan to schedule jobs with second precision you may need to override the default schedule poll interval so it is lower than the interval of your jobs:
 
 ```ruby
-Sidekiq.options[:average_scheduled_poll_interval] = 10
+Sidekiq[:average_scheduled_poll_interval] = 10
 ```
 
 The default value at time of writing is 30 seconds. See [under the hood](#under-the-hood) for more details.
@@ -350,7 +350,7 @@ Sidekiq-Cron adds itself into this start procedure and starts another thread wit
 Sidekiq-Cron is checking jobs to be enqueued every 30s by default, you can change it by setting:
 
 ```ruby
-Sidekiq.options[:average_scheduled_poll_interval] = 10
+Sidekiq[:average_scheduled_poll_interval] = 10
 ```
 
 Sidekiq-Cron is safe to use with multiple Sidekiq processes or nodes. It uses a Redis sorted set to determine that only the first process who asks can enqueue scheduled jobs into the queue.

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -478,7 +478,8 @@ module Sidekiq
           jid: jid,
           enqueued: @last_enqueue_time
         }
-        @history_size ||= (Sidekiq.options[:cron_history_size] || 10).to_i - 1
+        cron_history_size = Sidekiq.respond_to?(:[]) ? Sidekiq[:cron_history_size] : Sidekiq.options[:cron_history_size]
+        @history_size ||= (cron_history_size || 10).to_i - 1
         Sidekiq.redis do |conn|
           conn.lpush jid_history_key,
                      Sidekiq.dump_json(jid_history)


### PR DESCRIPTION
Since Sidekiq 6.5.0, using `Sidekiq.options[:config_var]` throws a warning: https://github.com/mperham/sidekiq/pull/5340/files#diff-2eecd3565b38823c09513903afa6686627d3ba8d883d520d3a83db61375e5ddeR72

> 2022-06-11T09:47:02.416Z pid=88697 tid=2k9 WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: [".../gems/sidekiq-cron-1.5.1/lib/sidekiq/cron/job.rb:481:in `add_jid_history'", ".../gems/sidekiq-cron-1.5.1/lib/sidekiq/cron/job.rb:73:in `enque!'"]

This change uses the new API, if it's available.

Before (mperham/sidekiq@eddc11ba): `Sidekiq.respond_to?(:[]) # => false`
After (mperham/sidekiq@67daa7a4): `Sidekiq.respond_to?(:[]) # => true`
