### PR TITLE
Fix Sidekiq.options warning for sidekiq-cron v1.6.0

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -1,6 +1,7 @@
 require 'fugit'
 require 'sidekiq'
 require 'sidekiq/cron/support'
+require 'sidekiq/options'
 
 module Sidekiq
   module Cron

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -478,8 +478,8 @@ module Sidekiq
           jid: jid,
           enqueued: @last_enqueue_time
         }
-        cron_history_size = Sidekiq.respond_to?(:[]) ? Sidekiq[:cron_history_size] : Sidekiq.options[:cron_history_size]
-        @history_size ||= (cron_history_size || 10).to_i - 1
+
+        @history_size ||= (SidekiqOptions[:cron_history_size] || 10).to_i - 1
         Sidekiq.redis do |conn|
           conn.lpush jid_history_key,
                      Sidekiq.dump_json(jid_history)

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -479,7 +479,7 @@ module Sidekiq
           enqueued: @last_enqueue_time
         }
 
-        @history_size ||= (SidekiqOptions[:cron_history_size] || 10).to_i - 1
+        @history_size ||= (Sidekiq::Options[:cron_history_size] || 10).to_i - 1
         Sidekiq.redis do |conn|
           conn.lpush jid_history_key,
                      Sidekiq.dump_json(jid_history)

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -10,8 +10,8 @@ module Sidekiq
     # The Poller checks Redis every N seconds for sheduled cron jobs
     class Poller < Sidekiq::Scheduled::Poller
       def initialize
-        Sidekiq.configure_server do |config|
-          Sidekiq::Options[config, :poll_interval_average] = POLL_INTERVAL
+        Sidekiq.configure_server do
+          Sidekiq::Options[:poll_interval_average] = POLL_INTERVAL
         end
 
         if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -11,7 +11,7 @@ module Sidekiq
     class Poller < Sidekiq::Scheduled::Poller
       def initialize
         Sidekiq.configure_server do |config|
-          Sidekiq::Options.set_config(config, :poll_interval_average, POLL_INTERVAL)
+          Sidekiq::Options[config, :poll_interval_average] = POLL_INTERVAL
         end
 
         if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -1,23 +1,20 @@
 require 'sidekiq'
 require 'sidekiq/cron'
 require 'sidekiq/scheduled'
+require 'sidekiq/options'
 
 module Sidekiq
   module Cron
-    POLL_INTERVAL = 30
+    POLL_INTERVAL = Sidekiq::Options[:average_scheduled_poll_interval] || 30
 
     # The Poller checks Redis every N seconds for sheduled cron jobs
     class Poller < Sidekiq::Scheduled::Poller
       def initialize
         Sidekiq.configure_server do |config|
-          if config.respond_to?(:[])
-            config[:poll_interval_average] = config[:average_scheduled_poll_interval] || POLL_INTERVAL
-          else
-            config.options[:poll_interval_average] = config.options[:average_scheduled_poll_interval] || POLL_INTERVAL
-          end
+          Sidekiq::Options.set_config(config, :poll_interval_average, POLL_INTERVAL)
         end
 
-        if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("6.5.0")
+        if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
           # Sidekiq Poller init requires a config argument
           super(Sidekiq)
         else

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -1,9 +1,10 @@
-require "sidekiq"
-require "sidekiq/cron/job"
+require 'sidekiq'
+require 'sidekiq/cron/job'
+require 'sidekiq/options'
 
 if Sidekiq.server?
   Sidekiq.configure_server do |config|
-    schedule_file = Sidekiq::Options[:cron_schedule_file] || "config/schedule.yml"
+    schedule_file = Sidekiq::Options[:cron_schedule_file] || 'config/schedule.yml'
 
     if File.exist?(schedule_file)
       config.on(:startup) do

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -3,7 +3,7 @@ require "sidekiq/cron/job"
 
 if Sidekiq.server?
   Sidekiq.configure_server do |config|
-    schedule_file = SidekiqOptions[:cron_schedule_file] || "config/schedule.yml"
+    schedule_file = Sidekiq::Options[:cron_schedule_file] || "config/schedule.yml"
 
     if File.exist?(schedule_file)
       config.on(:startup) do

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -3,7 +3,8 @@ require "sidekiq/cron/job"
 
 if Sidekiq.server?
   Sidekiq.configure_server do |config|
-    schedule_file = config.options[:cron_schedule_file] || "config/schedule.yml"
+    cron_schedule_file = Sidekiq.respond_to?(:[]) ? Sidekiq[:cron_schedule_file] : Sidekiq.options[:cron_schedule_file]
+    schedule_file = cron_schedule_file || "config/schedule.yml"
 
     if File.exist?(schedule_file)
       config.on(:startup) do

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -3,8 +3,7 @@ require "sidekiq/cron/job"
 
 if Sidekiq.server?
   Sidekiq.configure_server do |config|
-    cron_schedule_file = Sidekiq.respond_to?(:[]) ? Sidekiq[:cron_schedule_file] : Sidekiq.options[:cron_schedule_file]
-    schedule_file = cron_schedule_file || "config/schedule.yml"
+    schedule_file = SidekiqOptions[:cron_schedule_file] || "config/schedule.yml"
 
     if File.exist?(schedule_file)
       config.on(:startup) do

--- a/lib/sidekiq/cron/sidekiq_options.rb
+++ b/lib/sidekiq/cron/sidekiq_options.rb
@@ -1,0 +1,7 @@
+require "sidekiq"
+
+module SidekiqOptions
+  def self.[](key)
+    Sidekiq.respond_to?(:[]) ? Sidekiq[key] : Sidekiq.options[key]
+  end
+end

--- a/lib/sidekiq/cron/sidekiq_options.rb
+++ b/lib/sidekiq/cron/sidekiq_options.rb
@@ -1,7 +1,0 @@
-require "sidekiq"
-
-module SidekiqOptions
-  def self.[](key)
-    Sidekiq.respond_to?(:[]) ? Sidekiq[key] : Sidekiq.options[key]
-  end
-end

--- a/lib/sidekiq/options.rb
+++ b/lib/sidekiq/options.rb
@@ -6,7 +6,7 @@ module Sidekiq
       new_version? ? Sidekiq[key] : Sidekiq.options[key]
     end
 
-    def self.set_config(config, key, value)
+    def self.[]=(config, key, value)
       new_version? ? config[key] = value : config.options[key] = value
     end
 

--- a/lib/sidekiq/options.rb
+++ b/lib/sidekiq/options.rb
@@ -6,8 +6,8 @@ module Sidekiq
       new_version? ? Sidekiq[key] : Sidekiq.options[key]
     end
 
-    def self.[]=(config, key, value)
-      new_version? ? config[key] = value : config.options[key] = value
+    def self.[]=(key, value)
+      new_version? ? Sidekiq[key] = value : Sidekiq.options[key] = value
     end
 
     # sidekiq --version >= 6.5.0

--- a/lib/sidekiq/options.rb
+++ b/lib/sidekiq/options.rb
@@ -1,0 +1,9 @@
+require "sidekiq"
+
+module Sidekiq
+  module Options
+    def self.[](key)
+      Sidekiq.respond_to?(:[]) ? Sidekiq[key] : Sidekiq.options[key]
+    end
+  end
+end

--- a/lib/sidekiq/options.rb
+++ b/lib/sidekiq/options.rb
@@ -1,4 +1,4 @@
-require "sidekiq"
+require 'sidekiq'
 
 module Sidekiq
   module Options

--- a/lib/sidekiq/options.rb
+++ b/lib/sidekiq/options.rb
@@ -3,7 +3,16 @@ require 'sidekiq'
 module Sidekiq
   module Options
     def self.[](key)
-      Sidekiq.respond_to?(:[]) ? Sidekiq[key] : Sidekiq.options[key]
+      new_version? ? Sidekiq[key] : Sidekiq.options[key]
+    end
+
+    def self.set_config(config, key, value)
+      new_version? ? config[key] = value : config.options[key] = value
+    end
+
+    # sidekiq --version >= 6.5.0
+    def self.new_version?
+      @new_version ||= Sidekiq.respond_to?(:[])
     end
   end
 end


### PR DESCRIPTION
`Sidekiq.options` warning should be resolved on PR #338. 
But on PR #337 still used `Sidekiq.options` at https://github.com/ondrejbartas/sidekiq-cron/pull/337/files#diff-74c7adba1e1cde8fd26e2a46f0e03b37e9039f3a73ff16776ca21f4555ff7185R6

