### PR TITLE
Prepare release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 1.7.0
 
 - Enable to use cron notation in natural language (ie `every 30 minutes`) (https://github.com/ondrejbartas/sidekiq-cron/pull/312)
+- Fix `date_as_argument` feature to add timestamp argument at every cron job execution (https://github.com/ondrejbartas/sidekiq-cron/pull/329)
+- Introduce `Sidekiq::Options` to centralize reading/writing options from different Sidekiq versions (https://github.com/ondrejbartas/sidekiq-cron/pull/341)
+- Make auto schedule loading compatible with Array format (https://github.com/ondrejbartas/sidekiq-cron/pull/345)
 
 ## 1.6.0
 
@@ -55,7 +58,7 @@ All notable changes to this project will be documented in this file.
 
 - Updated readme
 - Fix unit tests - changed argument error when getting invalid cron format
-- When fallbacking old job enqueued time use `Time.parse` without format (so ruby can decide best method to parse it)
+- When fallbacking old job enqueued time use `Time.parse` without format (so Ruby can decide best method to parse it)
 - Add option `date_as_argument` which will add to your job arguments on last place `Time.now.to_f` when it was eneuqued
 - Add option `description` which will allow you to add notes to your jobs so in web view you can see it
 - Fixed translations
@@ -79,8 +82,8 @@ All notable changes to this project will be documented in this file.
 - Fix poller to enqueu all jobs in poll start time
 - Add performance test for enqueue of jobs (10 000 jobs in less than 19s)
 - Fix problem with default queue
-- Remove redis-namespace from dependencies
-- Update ruby versions in travis
+- Remove `redis-namespace` from dependencies
+- Update Ruby versions in Travis
 
 ## 0.5.0
 
@@ -92,7 +95,7 @@ All notable changes to this project will be documented in this file.
 - Add Russian locale
 - User Rack.env in tests
 - Faster enqueue of jobs
-- Permit to use ActiveJob::Base.queue_name_delimiter
+- Permit to use `ActiveJob::Base.queue_name_delimiter`
 - Fix problem with multiple times enqueue #84
 - Fix problem with enqueue of unknown class
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ gem "sidekiq-cron"
   'queue' => 'name of queue',
   'args' => '[Array or Hash] of arguments which will be passed to perform method',
   'date_as_argument' => true, # add the time of execution as last argument of the perform method
-  'active_job' => true,  # enqueue job through rails 4.2+ active job interface
-  'queue_name_prefix' => 'prefix', # rails 4.2+ active job queue with prefix
-  'queue_name_delimiter' => '.',  # rails 4.2+ active job queue with custom delimiter
-  'description' => 'A sentence describing what work this job performs.'
+  'active_job' => true,  # enqueue job through Rails 4.2+ Active Job interface
+  'queue_name_prefix' => 'prefix', # Rails 4.2+ Active Job queue with prefix
+  'queue_name_delimiter' => '.', # Rails 4.2+ Active Job queue with custom delimiter
+  'description' => 'A sentence describing what work this job performs'
   'status' => 'disabled' # default: enabled
 }
 ```

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -252,7 +252,7 @@ module Sidekiq
 
       # Destroy job by name.
       def self.destroy name
-        #if name is hash try to get name from it
+        # If name is hash try to get name from it.
         name = name[:name] || name['name'] if name.is_a?(Hash)
 
         if job = find(name)

--- a/lib/sidekiq/cron/version.rb
+++ b/lib/sidekiq/cron/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Cron
-    VERSION = "1.6.0"
+    VERSION = "1.7.0"
   end
 end


### PR DESCRIPTION
Main changes:

- Enable to use cron notation in natural language (ie `every 30 minutes`): #312
- Fix `date_as_argument` feature to add timestamp argument at every cron job execution: #329
- Make auto schedule loading compatible with Array format: #345

**Full diff** 👉🏼 https://github.com/ondrejbartas/sidekiq-cron/compare/v1.6.0...master

@ondrejbartas @honzasterba I think these changes deserve a new release ✨ ✨ 

