### PR TITLE
Update style for disabled job in dark theme.

### DIFF
--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -42,7 +42,7 @@
           <td style="<%= style %>"><%= t job.status %></td>
           <td style="<%= style %>">
             <a href="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>">
-              <b><%= job.name %></b>
+              <b style="<%= style %>"><%= job.name %></b>
             </a>
             <hr style="margin:3px;border:0;">
             <small>


### PR DESCRIPTION
Update job name color on dark theme to resolved issue #347

<img width="1172" alt="Screen Shot 2022-08-01 at 9 50 20 am" src="https://user-images.githubusercontent.com/3401929/182063174-21960f5a-9140-4c6e-813d-08860e6f453f.png">
 