### PR TITLE
Fix loading last_enqueue_time.

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -281,11 +281,12 @@ module Sidekiq
         @status = args['status'] || status_from_redis
 
         # Set last enqueue time - from args or from existing job.
-        if args['last_enqueue_time'] && !args['last_enqueue_time'].empty?
-          @last_enqueue_time = parse_enqueue_time(args['last_enqueue_time'])
-        else
-          @last_enqueue_time = last_enqueue_time_from_redis
-        end
+        last_enqueue_time = if args['last_enqueue_time'] && !args['last_enqueue_time'].empty?
+                              parse_enqueue_time(args['last_enqueue_time'])
+                            else
+                              last_enqueue_time_from_redis
+                            end
+        @last_enqueue_time = last_enqueue_time&.strftime(LAST_ENQUEUE_TIME_FORMAT)
 
         # Get right arguments for job.
         @symbolize_args = args["symbolize_args"] == true || ("#{args["symbolize_args"]}" =~ (/^(true|t|yes|y|1)$/i)) == 0 || false


### PR DESCRIPTION
In my laptop, loading `@last_enqueue_time` raises a parse error:

```
2022-08-08T05:59:06.992Z pid=58672 tid=2kqk WARN: Date::Error: invalid date
2022-08-08T05:59:06.992Z pid=58672 tid=2kqk WARN: /Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:632:in `parse'
/Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:632:in `rescue in parse_enqueue_time'
/Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:629:in `parse_enqueue_time'
/Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:285:in `initialize'
```

![image](https://user-images.githubusercontent.com/706434/183349600-8c675b48-1ce8-4bfe-8b3e-571518b2ad5b.png)

This PR makes `@last_enqueue_time` is always `LAST_ENQUEUE_TIME_FORMAT` string.