### PR TITLE
Fix deprecation warnings with redis-rb v4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Fix deprecation warnings with redis-rb v4.8.0 (https://github.com/ondrejbartas/sidekiq-cron/pull/356
+
 ## 1.7.0
 
 - Enable to use cron notation in natural language (ie `every 30 minutes`) (https://github.com/ondrejbartas/sidekiq-cron/pull/312)

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -465,7 +465,7 @@ module Sidekiq
         Sidekiq.redis do |conn|
 
           # Add to set of all jobs
-          conn.sadd self.class.jobs_key, redis_key
+          conn.sadd self.class.jobs_key, [redis_key]
 
           # Add informations for this job!
           conn.hmset redis_key, *hash_to_redis(to_hash)
@@ -502,7 +502,7 @@ module Sidekiq
       def destroy
         Sidekiq.redis do |conn|
           # Delete from set.
-          conn.srem self.class.jobs_key, redis_key
+          conn.srem self.class.jobs_key, [redis_key]
 
           # Delete runned timestamps.
           conn.del job_enqueued_key

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -929,7 +929,7 @@ describe "Cron Job" do
       Sidekiq::Cron::Job.create(@args.merge(name: "Test3"))
 
       Sidekiq.redis do |conn|
-        conn.sadd Sidekiq::Cron::Job.jobs_key, "some_other_key"
+        conn.sadd Sidekiq::Cron::Job.jobs_key, ["some_other_key"]
       end
 
       assert_equal Sidekiq::Cron::Job.all.size, 3, "All have to return only valid 3 jobs"


### PR DESCRIPTION
redis-rb v4.8.0 gives a deprecation warning when calling `sadd` and
`srem` with a single argument:
https://github.com/redis/redis-rb/blob/4.x/CHANGELOG.md#480

```
Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead.
```

Resolving the deprecation warning by following Sidekiq's approach of
wrapping the argument as an array:
https://github.com/mperham/sidekiq/commit/09dacfed8f3f0b42833122b138639d22c71e3d56

Fixes #355