### PR TITLE
Fix compatibility with Sidekiq v6.5.7

### DIFF
--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -43,7 +43,7 @@ module Sidekiq
         handle_exception(ex) if respond_to?(:handle_exception)
       end
 
-      def poll_interval_average
+      def poll_interval_average(process_count = 1)
         @config[:cron_poll_interval] || POLL_INTERVAL
       end
     end


### PR DESCRIPTION
We don't use the process count parameter so we just set a default value so that this works with previous versions too

Closes #365