### PR TITLE
Allow disabling of cron polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Sidekiq[:cron_poll_interval] = 10
 
 Sidekiq-Cron is safe to use with multiple Sidekiq processes or nodes. It uses a Redis sorted set to determine that only the first process who asks can enqueue scheduled jobs into the queue.
 
+When running with many Sidekiq processes, the polling can add significant load to Redis. You can disable polling on some processes by setting `Sidekiq[:cron_poll_interval] = 0` on these processes.
+
 ## Contributing
 
 **Thanks to all [contributors](https://github.com/ondrejbartas/sidekiq-cron/graphs/contributors), you’re awesome and this wouldn’t be possible without you!**

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -8,30 +8,34 @@ require 'sidekiq/cron/poller'
 module Sidekiq
   module Cron
     module Launcher
+      DEFAULT_POLL_INTERVAL = 30
+
       # Add cron poller to launcher.
       attr_reader :cron_poller
 
       # Add cron poller and execute normal initialize of Sidekiq launcher.
       def initialize(options)
-        @cron_poller = Sidekiq::Cron::Poller.new(options)
+        options[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if options[:cron_poll_interval].nil?
+
+        @cron_poller = Sidekiq::Cron::Poller.new(options) if options[:cron_poll_interval] > 0
         super(options)
       end
 
       # Execute normal run of launcher and run cron poller.
       def run
         super
-        cron_poller.start
+        cron_poller.start if @cron_poller
       end
 
       # Execute normal quiet of launcher and quiet cron poller.
       def quiet
-        cron_poller.terminate
+        cron_poller.terminate if @cron_poller
         super
       end
 
       # Execute normal stop of launcher and stop cron poller.
       def stop
-        cron_poller.terminate
+        cron_poller.terminate if @cron_poller
         super
       end
     end

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -5,8 +5,6 @@ require 'sidekiq/options'
 
 module Sidekiq
   module Cron
-    POLL_INTERVAL = 30
-
     # The Poller checks Redis every N seconds for sheduled cron jobs.
     class Poller < Sidekiq::Scheduled::Poller
       def initialize(options = {})
@@ -44,7 +42,7 @@ module Sidekiq
       end
 
       def poll_interval_average(process_count = 1)
-        @config[:cron_poll_interval] || POLL_INTERVAL
+        @config[:cron_poll_interval]
       end
     end
   end

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -1,0 +1,33 @@
+require './test/test_helper'
+
+describe 'Cron launcher' do
+  describe 'initialization' do
+    before do
+      Sidekiq[:cron_poll_interval] = nil
+    end
+
+    it 'initializes poller with default poll interval when not configured' do
+      Sidekiq::Cron::Poller.expects(:new).with do |options|
+        assert_equal Sidekiq::Cron::Launcher::DEFAULT_POLL_INTERVAL, options[:cron_poll_interval]
+      end
+
+      Sidekiq::Launcher.new(Sidekiq)
+    end
+
+    it 'initializes poller with the configured poll interval' do
+      Sidekiq::Cron::Poller.expects(:new).with do |options|
+        assert_equal 99, options[:cron_poll_interval]
+      end
+
+      Sidekiq[:cron_poll_interval] = 99
+      Sidekiq::Launcher.new(Sidekiq)
+    end
+
+    it 'does not initialize the poller when interval is 0' do
+      Sidekiq::Cron::Poller.expects(:new).never
+
+      Sidekiq[:cron_poll_interval] = 0
+      Sidekiq::Launcher.new(Sidekiq)
+    end
+  end
+end


### PR DESCRIPTION
When running with very many Sidekiq processes, polling on each one of them can be expensive and unnecessary too.

This allows disabling polling by setting `cron_poll_interval` to zero.