### PR TITLE
Fix Spanish translation for enabled/disabled states

### DIFF
--- a/lib/sidekiq/cron/locales/es.yml
+++ b/lib/sidekiq/cron/locales/es.yml
@@ -18,5 +18,5 @@ es:
   LastEnqueued: Último trabajo en cola
   NoCronJobsWereFound: No se encontraron trabajos
   NoHistoryWereFound: No se encontró histórico de trabajos
-  disabled: activo
-  enabled: inactivo
+  disabled: inactivo
+  enabled: activo


### PR DESCRIPTION
The enabled and disabled translations were swapped. This corrects "enabled" to "activo" (active) and "disabled" to "inactivo" (inactive).