### PR TITLE
Allow setting `config.cron_schedule_file` to `nil` to prevent automatic loading jobs from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All configuration options:
 Sidekiq::Cron.configure do |config|
   config.enabled = false # Default is true
   config.cron_poll_interval = 10 # Default is 30
-  config.cron_schedule_file = 'config/my_schedule.yml' # Default is 'config/schedule.yml'
+  config.cron_schedule_file = 'config/my_schedule.yml' # Default is 'config/schedule.yml'. Set to `nil` to disable automatic loading.
   config.cron_history_size = 20 # Default is 10
   config.default_namespace = 'statistics' # Default is 'default'
   config.available_namespaces = %w[statistics maintenance billing] # Default is `[config.default_namespace]`
@@ -404,6 +404,8 @@ There are multiple ways to load the jobs from a YAML file
     # config/initializers/sidekiq.rb
 
     Sidekiq.configure_server do |config|
+      config.cron_schedule_file = nil # disable automatically loading from default `config/schedule.yml` if available
+
       config.on(:startup) do
         schedule_file = "config/users_schedule.yml"
 
@@ -415,6 +417,9 @@ There are multiple ways to load the jobs from a YAML file
       end
     end
     ```
+
+    **Important**: When you manually load schedules, you need to set the `config.cron_schedule_file` to `nil` to prevent the gem from 
+    trying to load from `config/schedule.yml` and overriding your previously loaded content.
 
 ### Finding jobs
 

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -12,6 +12,8 @@ module Sidekiq
       end
 
       def has_schedule_file?
+        return false if schedule_file_name.nil?
+
         File.exist?(schedule_file_name)
       end
 
@@ -30,6 +32,8 @@ module Sidekiq
       end
 
       def schedule_file_name
+        return if schedule_file_name_from_config.nil?
+
         @schedule_file_name ||= yml_to_yaml_unless_file_exists(schedule_file_name_from_config)
       end
 

--- a/test/unit/schedule_loader_test.rb
+++ b/test/unit/schedule_loader_test.rb
@@ -31,6 +31,18 @@ describe 'ScheduleLoader' do
     end
   end
 
+  describe 'cron_schedule_file is nil' do
+    before do
+      Sidekiq::Cron.configuration.cron_schedule_file = nil
+    end
+
+    it 'does not load the schedule file' do
+      Sidekiq::Cron::Job.expects(:load_from_hash!).never
+      Sidekiq::Cron::Job.expects(:load_from_array!).never
+      Sidekiq::Options[:lifecycle_events][:startup].first.call
+    end
+  end
+
   describe 'Schedule file does not exist' do
     before do
       Sidekiq::Cron.configuration.cron_schedule_file = 'test/unit/fixtures/schedule_does_not_exist.yml'


### PR DESCRIPTION
## Context

I have a system where I've split the schedule into multiple yaml files that can be conditionally loaded. I've followed the example from: https://github.com/sidekiq-cron/sidekiq-cron#loading-jobs-from-schedule-file

Because one of the files are still called `config/schedule.yml` (this is the base one that we always want to load), it is always executed, even after I've manually loaded them before.

What we ended up doing is we set a custom name in the configuration for a file that doesn't exist. I believe this is suboptimal.

### Proposal

If `config.cron_schedule_file` is set to `nil` we never try to load it.